### PR TITLE
Fixes minor bug with ClosureCleaner

### DIFF
--- a/src/test/scala/com/twitter/chill/ClosureCleanerSpec.scala
+++ b/src/test/scala/com/twitter/chill/ClosureCleanerSpec.scala
@@ -23,12 +23,13 @@ class ClosureCleanerSpec extends Specification {
     println(x.getClass)
     println(x.getClass.getDeclaredFields.map { _.toString }.mkString("  "))
   }
-  "Should clean normal objects" in {
+  "ClosureCleaner" should {
+  "clean normal objects" in {
     val myList = List(1,2,3)
     ClosureCleaner(myList)
     myList must be_==(List(1,2,3))
   }
-  "Should clean actual closures" in {
+  "clean actual closures" in {
     val myFun = { x: Int => x*2 }
 
     ClosureCleaner(myFun)
@@ -41,7 +42,7 @@ class ClosureCleanerSpec extends Specification {
     t must be_==(Test(3))
   }
 
-  "Should handle outers with constructors" in {
+  "handle outers with constructors" in {
 
     class Test(x: String) {
       val l = x.size
@@ -54,5 +55,17 @@ class ClosureCleanerSpec extends Specification {
     //println(ClosureCleaner.getOutersOf(fn))
     ClosureCleaner(fn)
     fn("hey") must be_==(20)
+  }
+  "Handle functions in traits" in {
+    val fn = BaseFns2.timesByMult
+    ClosureCleaner(fn)
+    fn(10) must be_==(50)
+  }
+  "Handle captured vals" in {
+    val answer = 42
+    val fn = { x: Int => answer * x }
+    ClosureCleaner(fn)
+    fn(10) must be_==(420)
+  }
   }
 }

--- a/src/test/scala/com/twitter/chill/FunctionSerialization.scala
+++ b/src/test/scala/com/twitter/chill/FunctionSerialization.scala
@@ -29,6 +29,15 @@ object BaseFns extends AwesomeFns {
   def apply(x: Int) = myfun.apply(x)
 }
 
+trait AwesomeFn2 {
+  def mult: Int
+  val timesByMult = { x: Int => mult * x }
+}
+
+object BaseFns2 extends AwesomeFn2 {
+  def mult = 5
+}
+
 class FunctionSerialization extends Specification with KryoSerializer {
   noDetailedDiffs() //Fixes issue for scala 2.9
 
@@ -48,6 +57,10 @@ class FunctionSerialization extends Specification with KryoSerializer {
     }
     "roundtrip the object" in {
       rt(BaseFns) must be_==(BaseFns)
+    }
+    "Handle traits with abstract vals/def" in {
+      rt(BaseFns2) must be_==(BaseFns2)
+      rt(BaseFns2.timesByMult).apply(10) must be_==(50)
     }
   }
 }


### PR DESCRIPTION
The bugfix is here:

```
-        getOutersOf(myOuter, (f.getType, myOuter) :: hierarchy)
     102    
+        // Note that if you use f.getType you might get an interface. No good
     103    
+        val outerType = myOuter.getClass
     104    
+        getOutersOf(myOuter, (outerType, myOuter) :: hierarchy)
```

The rest is refactoring.
