### PR TITLE
Adds Serializer for PriorityQueue

### DIFF
--- a/src/main/scala/com/twitter/chill/KryoSerializer.scala
+++ b/src/main/scala/com/twitter/chill/KryoSerializer.scala
@@ -91,6 +91,7 @@ object KryoSerializer {
     // wrapper array is abstract
     newK.forSubclass[WrappedArray[Any]](new WrappedArraySerializer[Any])
       .forSubclass[BitSet](new BitSetSerializer)
+      .forSubclass[java.util.PriorityQueue[AnyRef]](new PriorityQueueSerializer[AnyRef])
       .forTraversableSubclass(Queue.newBuilder[Any])
       // List is a sealed class, so there are only two subclasses:
       .forTraversableSubclass(List.newBuilder[Any])

--- a/src/main/scala/com/twitter/chill/PriorityQueueSerializer.scala
+++ b/src/main/scala/com/twitter/chill/PriorityQueueSerializer.scala
@@ -1,0 +1,52 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.chill
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.{ Serializer => KSerializer }
+import com.esotericsoftware.kryo.io.{ Input, Output }
+
+import java.util.{PriorityQueue => PQue, Comparator}
+import scala.collection.JavaConverters._
+
+class PriorityQueueSerializer[A<:AnyRef] extends KSerializer[PQue[A]] {
+  private val field = {
+    val f = classOf[PQue[A]].getDeclaredField("comparator")
+    f.setAccessible(true)
+    f
+  }
+  def getComparator(q: PQue[A]): Comparator[A] = {
+    field.get(q).asInstanceOf[Comparator[A]]
+  }
+  def write(k: Kryo, o: Output, v: PQue[A]) {
+    k.writeClassAndObject(o, getComparator(v))
+    o.writeInt(v.size, true)
+    v.iterator.asScala.foreach { (a: A) => k.writeClassAndObject(o, a); o.flush }
+  }
+  def read(k: Kryo, i: Input, c: Class[PQue[A]]): PQue[A] = {
+    val comp = k.readClassAndObject(i).asInstanceOf[Comparator[A]]
+    val sz = i.readInt(true)
+    // can't create with size 0:
+    val result = new PQue[A](1 max sz, comp)
+    var idx = 0
+    while(idx < sz) {
+      result.add(k.readClassAndObject(i).asInstanceOf[A])
+      idx += 1
+    }
+    result
+  }
+}

--- a/src/test/scala/com/twitter/chill/KryoSpec.scala
+++ b/src/test/scala/com/twitter/chill/KryoSpec.scala
@@ -134,5 +134,19 @@ class KryoSpec extends Specification with KryoSerializer {
       }}
       rt(k, TestCaseClassForSerialization("hey", 42)) must be_==(TestCaseClassForSerialization("hey", 42))
     }
+    "Handle PriorityQueue" in {
+      import scala.collection.JavaConverters._
+      val ord = Ordering.fromLessThan[(Int,Int)] { (l, r) => l._1 < r._1 }
+      val q = new java.util.PriorityQueue[(Int,Int)](3, ord)
+      q.add((2,3))
+      q.add((4,5))
+      def toList[A](q: java.util.PriorityQueue[A]): List[A] =
+        q.iterator.asScala.toList
+      val qlist = toList(q)
+      val newQ = rt(q)
+      toList(newQ) must be_==(qlist)
+      newQ.add((1,1))
+      newQ.add((2,1)) must beTrue
+    }
   }
 }


### PR DESCRIPTION
The new algebird priorityqueue monoid hits the bug that ordering is lost if used across map/reduce boundaries.
