### PR TITLE
Update README: Chill now supports Scala 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Scala extensions for the [Kryo serialization library](http://code.google.com/p/k
 Chill provides a a number of Kryo serializers and an Option-like type called the MeatLocker. The MeatLocker allows you to box Kryo-serializable objects and deserialize them lazily on the first call to `get`:
 
 ```scala
-val boxedItem = MeatLocker(someItem)
+val boxedItem = com.twitter.chill.MeatLocker(someItem)
 
 // boxedItem is java.io.Serializable no matter what it contains.
 val box = roundTripThroughJava(boxedItem)
@@ -33,7 +33,7 @@ Chill provides support for singletons, scala Objects and the following types:
 
 ## Maven
 
-Current version is `0.2.0`. groupid=`"com.twitter"` artifact=`"chill_2.9.2"`.
+Current version is `0.2.0`. groupid=`"com.twitter"` artifact=`"chill_2.9.2"` or artifact=`"chill_2.10"`.
 
 ## Authors
 


### PR DESCRIPTION
Fix #29
