### PR TITLE
Add test case for serialization of custom objects.

### DIFF
--- a/chill-scala/src/test/scala/com/twitter/chill/CustomSerializationSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/CustomSerializationSpec.scala
@@ -1,0 +1,62 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.chill
+
+import org.specs._
+
+import com.twitter.bijection.Bijection
+
+/*
+* This is just a test case for Kryo to deal with. It should
+* be outside KryoSpec, otherwise the enclosing class, KryoSpec
+* will also need to be serialized
+*/
+case class Point(x: Int, y: Int)
+case class Color(name: String)
+case class ColoredPoint(color: Color, point: Point)
+
+class CustomSerializationSpec extends Specification with BaseProperties {
+  "Custom KryoSerializers and KryoDeserializers" should {
+    "serialize objects that have registered serialization" in {
+      import KryoImplicits.toRich
+
+      // write bijections
+      implicit val pointBijection = Bijection.build[Point, (Int,Int)](
+        Point.unapply(_).get)(
+        (Point.apply _).tupled)
+      implicit val colorBijection = Bijection.build[Color, String](
+        Color.unapply(_).get)(
+        Color.apply)
+      implicit val coloredPointBijection = Bijection.build[ColoredPoint, (Color, Point)](
+        ColoredPoint.unapply(_).get)(
+        (ColoredPoint.apply _).tupled)
+
+      val MyKryoInjection = new KryoBijection {
+        override def getKryo = super.getKryo
+          .forClassViaBijection[Point, (Int,Int)]
+          .forClassViaBijection[Color, (String)]
+          .forClassViaBijection[ColoredPoint, (Color, Point)]
+      }
+
+      val color = Color("blue")
+      val point = Point(5, 6)
+      val coloredPoint = ColoredPoint(color, point)
+
+      rt(coloredPoint) must_== coloredPoint
+    }
+  }
+}


### PR DESCRIPTION
Twitter Chill is a great project but it's sparse in documentation.  I want to serialize my own classes using the serialization routines Twitter has for base types.  In particular, I want a high-level abstraction so for my custom class `Foo` I can write `Serializer(foo)` and use `Serializer.invert(bytes)` to get a deserialized foo.

I wrote a test case that demonstrates how I would do this.  It's easy to write Bijections between case classes and tuples and register them with a custom KryoInjection class.  Please merge this if you think this is the "proper" way to do this.  Otherwise, let me know what I'm doing wrong and how I can do it right!
