### PR TITLE
issue #60: properly handle small Scala maps when registration is required

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/KryoSerializer.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/KryoSerializer.scala
@@ -101,6 +101,12 @@ object KryoSerializer {
       .forTraversableClass(Vector.empty[Any])
       .forTraversableSubclass(IndexedSeq.empty[Any])
       .forTraversableSubclass(Set.empty[Any])
+      // specifically register small maps since Scala represents them differently
+      .forConcreteTraversableClass(Map[Any, Any]('a -> 'a))
+      .forConcreteTraversableClass(Map[Any, Any]('a -> 'a, 'b -> 'b))
+      .forConcreteTraversableClass(Map[Any, Any]('a -> 'a, 'b -> 'b, 'c -> 'c))
+      .forConcreteTraversableClass(Map[Any, Any]('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd))
+      .forConcreteTraversableClass(Map[Any, Any]('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd, 'e -> 'e))
       // Add some maps
       .forTraversableSubclass(ListMap.empty[Any,Any])
       .forTraversableSubclass(HashMap.empty[Any,Any])

--- a/chill-scala/src/main/scala/com/twitter/chill/RichKryo.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/RichKryo.scala
@@ -91,6 +91,14 @@ class RichKryo(k: Kryo) {
     (implicit mf: ClassManifest[C], cbf: CanBuildFrom[C, T, C]): Kryo =
     forClass(new TraversableSerializer(isImmutable)(cbf))
 
+  def forConcreteTraversableClass[T, C <: Traversable[T]](c: C with Traversable[T], isImmutable: Boolean = true)
+    (implicit cbf: CanBuildFrom[C, T, C]): Kryo = {
+    // a ClassManifest is not used here since its erasure method does not return the concrete internal type
+    // that Scala uses for small immutable maps (i.e., scala.collection.immutable.Map$Map1)
+    k.register(c.getClass, new TraversableSerializer(isImmutable)(cbf))
+    k
+  }
+
   /** B has to already be registered, then use the KSerializer[B] to create KSerialzer[A]
    */
   def forClassViaBijection[A,B](implicit bij: ImplicitBijection[A,B], acmf: ClassManifest[A], bcmf: ClassManifest[B]): Kryo = {

--- a/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
@@ -166,5 +166,18 @@ class KryoSpec extends Specification with BaseProperties {
       roundtripped.pattern.pattern must be_==(test.pattern.pattern)
       roundtripped.findFirstIn("hilarious").isDefined must beTrue
     }
+    "Handle small immutable maps when registration is required" in {
+      val kryo = KryoBijection.getKryo
+      kryo.setRegistrationRequired(true)
+      val inj = KryoInjection.instance(kryo)
+      val m1 = Map('a -> 'a)
+      val m2 = Map('a -> 'a, 'b -> 'b)
+      val m3 = Map('a -> 'a, 'b -> 'b, 'c -> 'c)
+      val m4 = Map('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd)
+      val m5 = Map('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd, 'e -> 'e)
+      Seq(m1, m2, m3, m4, m5).foreach { m =>
+        rt(inj, m) must be_==(m)
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request addresses issue #60 that deals with properly serializing small Scala maps. It turns out that using `ClassManifest.erasure` doesn't return the proper class for small maps. For example, the above method returns `scala.collection.immutable.Map` instead of `scala.collection.immutable.Map$Map1` for the map `Map(1 -> 1)`. I've added a new method for serializing these beasts as well as a few unit tests for testing them. The new tests fail if you comment out the new registrations for these small maps.
