### PR TITLE
#62: support required registration for small immutable sets

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/KryoSerializer.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/KryoSerializer.scala
@@ -97,9 +97,15 @@ object KryoSerializer {
       .forTraversableSubclass(List.empty[Any])
       // add mutable Buffer before Vector, otherwise Vector is used
       .forTraversableSubclass(Buffer.empty[Any], isImmutable = false)
-      //Vector is a final class
+      // Vector is a final class
       .forTraversableClass(Vector.empty[Any])
       .forTraversableSubclass(IndexedSeq.empty[Any])
+      // specifically register small sets since Scala represents them differently
+      .forConcreteTraversableClass(Set[Any]('a))
+      .forConcreteTraversableClass(Set[Any]('a, 'b))
+      .forConcreteTraversableClass(Set[Any]('a, 'b, 'c))
+      .forConcreteTraversableClass(Set[Any]('a, 'b, 'c, 'd))
+      .forConcreteTraversableClass(Set[Any]('a, 'b, 'c, 'd, 'e))
       .forTraversableSubclass(Set.empty[Any])
       // specifically register small maps since Scala represents them differently
       .forConcreteTraversableClass(Map[Any, Any]('a -> 'a))

--- a/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
@@ -179,5 +179,18 @@ class KryoSpec extends Specification with BaseProperties {
         rt(inj, m) must be_==(m)
       }
     }
+    "Handle small immutable sets when registration is required" in {
+      val kryo = KryoBijection.getKryo
+      kryo.setRegistrationRequired(true)
+      val inj = KryoInjection.instance(kryo)
+      val s1 = Set('a)
+      val s2 = Set('a, 'b)
+      val s3 = Set('a, 'b, 'c)
+      val s4 = Set('a, 'b, 'c, 'd)
+      val s5 = Set('a, 'b, 'c, 'd, 'e)
+      Seq(s1, s2, s3, s4, s5).foreach { s =>
+        rt(inj, s) must be_==(s)
+      }
+    }
   }
 }


### PR DESCRIPTION
Good catch on the small immutable sets! This fix addresses it. If you don't register them, the new tests that I added will fail. Addresses #62 
