### PR TITLE
Catch fewer exceptions in KryoBijection.

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/KryoBijection.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/KryoBijection.scala
@@ -21,7 +21,7 @@ import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.twitter.bijection.{ Bijection, Injection }
 import org.objenesis.strategy.StdInstantiatorStrategy
 
-import scala.util.control.Exception.allCatch
+import scala.util.control.Exception.catching
 
 /**
  * KryoBijection is split into a trait and companion object to allow
@@ -93,6 +93,6 @@ class KryoInjectionInstance(kryo: Kryo, output: Output) extends Injection[Any, A
 
   def invert(b: Array[Byte]): Option[Any] = {
     input.setBuffer(b)
-    allCatch.opt(kryo.readClassAndObject(input))
+    catching(classOf[Exception]).opt(kryo.readClassAndObject(input))
   }
 }


### PR DESCRIPTION
Previously it caught everything, including OOME, etc.  OOME's are somewhat likely to occur when deserializing a large object.  Hiding this exception is very confusing.
