### PR TITLE
Make use of latest Kryo snapshot which provides Unsafe-based streams

### DIFF
--- a/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoDeserializer.java
+++ b/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoDeserializer.java
@@ -2,6 +2,7 @@ package com.twitter.chill.hadoop;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.UnsafeInput;
 import org.apache.hadoop.io.serializer.Deserializer;
 
 import java.io.DataInputStream;
@@ -34,7 +35,7 @@ public class KryoDeserializer implements Deserializer<Object> {
         byte[] bytes = new byte[inputStream.readInt()];
         inputStream.readFully( bytes );
 
-        return kryo.readObject(new Input(bytes), klass);
+        return kryo.readObject(new UnsafeInput(bytes), klass);
     }
 
     // TODO: Bump the kryo version, add a kryo.reset();

--- a/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerializer.java
+++ b/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerializer.java
@@ -2,6 +2,7 @@ package com.twitter.chill.hadoop;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.io.UnsafeOutput;
 import org.apache.hadoop.io.serializer.Serializer;
 
 import java.io.ByteArrayOutputStream;
@@ -32,7 +33,7 @@ public class KryoSerializer implements Serializer<Object> {
         // Clear buffer.
         byteStream.reset();
         // Write output to temorary buffer.
-        Output ko = new Output(byteStream);
+        Output ko = new UnsafeOutput(byteStream);
         kryo.writeObject(ko, o);
         ko.flush();
         // Copy from buffer to output stream.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys._
 import scala.collection.JavaConverters._
 
 object ChillBuild extends Build {
-  val kryoVersion = "2.21"
+  val kryoVersion = "2.22-SNAPSHOT"
 
   val sharedSettings = Project.defaultSettings ++
     mimaDefaultSettings ++ Seq(


### PR DESCRIPTION
Hi, 

As requested, I provide a pull request for the issue https://github.com/twitter/chill/issues/73
It compiles, but I could not test, because I don't have a local hadoop installation.

It would be nice if someone could give it a try and report any issues that may pop up during testing.
It would be also very interesting to know if there are any performance improvements.

Note: Right now I use UnsafeInput and UnsafeOutput constructors which do not use explicit buffer-size parameter and therefore Kryo will use the default size of 4096. It could be interesting to experiment with different buffer sizes to see how it affects performance.

-Leo