### PR TITLE
- add test for serialized fn containing a call to println

### DIFF
--- a/chill-scala/src/test/scala/com/twitter/chill/FunctionSerialization.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/FunctionSerialization.scala
@@ -40,8 +40,13 @@ object BaseFns2 extends AwesomeFn2 {
   def mult = 5
 }
 
-object Foo { def Bar = 1 }
+object Foo {
+    def Bar = 1
+}
+object Globals {
+    var temp = false
 
+}
 class FunctionSerialization extends Specification with BaseProperties {
   noDetailedDiffs() //Fixes issue for scala 2.9
 
@@ -70,5 +75,15 @@ class FunctionSerialization extends Specification with BaseProperties {
       val x = KryoInjection.invert(bytes)
       x.get.asInstanceOf[() => Int].apply() must be_==(Foo.Bar)
     }
+      "handle a closure to println" in {
+          Globals.temp = false
+          val bytes = KryoInjection(() => {
+                                        println();
+                                        Globals.temp = true
+                                    })
+          val inv = KryoInjection.invert(bytes)
+          inv.get.asInstanceOf[() => Unit].apply()
+          Globals.temp must be_==(true)
+      }
   }
 }


### PR DESCRIPTION
This test fails for me on scala 2.10.0 with:

```
[error] x Serialize objects with Fns should
[info]   + fn calling
[info]   + roundtrip the object
[info]   + Handle traits with abstract vals/def
[info]   + KryoInjection handle an example with closure to function
[error]   x handle a closure to println
[error]     Failed to invert: [B@99f4c2f (InversionFailure.scala:43)
[error]     com.twitter.bijection.InversionFailure$$anonfun$partialFailure$1.applyOrElse(InversionFailure.scala:43)
[error]     com.twitter.bijection.InversionFailure$$anonfun$partialFailure$1.applyOrElse(InversionFailure.scala:42)
[error]     scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:33)
[error]     scala.util.Failure.recoverWith(Try.scala:172)
[error]     com.twitter.bijection.Inversion$.attempt(Inversion.scala:30)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:97)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:71)
[error]     com.twitter.chill.KryoInjection$.invert(KryoInjection.scala:48)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:84)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:78)
[error]     org.specs.specification.LifeCycle$class.withCurrent(ExampleLifeCycle.scala:66)
[error]     org.specs.specification.Examples.withCurrent(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.ExampleExecution$$anonfun$3$$anonfun$apply$5.apply(ExampleLifeCycle.scala:219)
[error]     scala.Option.getOrElse(Option.scala:120)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:219)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:198)
[error]     org.specs.specification.ExampleExecution$$anonfun$2.apply(ExampleLifeCycle.scala:181)
[error]     org.specs.specification.ExampleExecution.execute(ExampleLifeCycle.scala:252)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.SpecificationExecutor$class.executeExample(SpecificationExecutor.scala:55)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleLifeCycle$class.executeExample(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.Examples.executeExamples(Examples.scala:80)
[error]     org.specs.specification.ExampleStructure$class.ownFailures(ExampleStructure.scala:58)
[error]     org.specs.specification.Examples.ownFailures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
[error]     scala.collection.AbstractTraversable.flatMap(Traversable.scala:105)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.failureAndErrors(HasResults.scala:61)
[error]     org.specs.specification.Examples.failureAndErrors(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.isOk(HasResults.scala:69)
[error]     org.specs.specification.Examples.isOk(Examples.scala:52)
[error]     org.specs.runner.NotifierRunner.reportSystem(NotifierRunner.scala:81)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:72)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:68)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     org.specs.runner.NotifierRunner.reportASpecification(NotifierRunner.scala:68)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:58)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:45)
[error]     org.specs.runner.Reporter$class.reportSpecs(Reporter.scala:195)
[error]     org.specs.runner.NotifierRunner.reportSpecs(NotifierRunner.scala:45)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:65)
[error]     sbt.TestRunner.delegateRun(TestFramework.scala:57)
[error]     sbt.TestRunner.run(TestFramework.scala:51)
[error]     sbt.TestRunner.runTest$1(TestFramework.scala:71)
[error]     sbt.TestRunner.run(TestFramework.scala:80)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:200)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$5.work(System.scala:71)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:18)
[error]     sbt.Execute.work(Execute.scala:238)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:160)
[error]     sbt.CompletionService$$anon$2.call(CompletionService.scala:30)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
[error]     java.lang.Thread.run(Thread.java:662)
[error]     java.lang.IllegalArgumentException: Can not set final scala.xml.Node field org.specs.specification.ExampleDescription.toXhtml to scala.collection.immutable.$colon$colon
[error] Serialization trace:
[error] toXhtml (org.specs.specification.ExampleDescription)
[error] exampleDesc (org.specs.specification.Example)
[error] childrenNodes (org.specs.specification.Sus)
[error] childrenNodes (com.twitter.chill.FunctionSerialization)
[error] $outer (com.twitter.chill.FunctionSerialization$$anonfun$6)
[error] $outer (com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29)
[error] $outer (com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29$$anonfun$5) (FieldSerializer.java:626)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:626)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:44)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:21)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:44)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:21)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.SerDeState.readClassAndObject(SerDeState.java:61)
[error]     com.twitter.chill.KryoInjectionInstance$$anonfun$invert$2.apply(KryoInjection.scala:97)
[error]     com.twitter.chill.KryoInjectionInstance$$anonfun$invert$2.apply(KryoInjection.scala:97)
[error]     com.twitter.bijection.Inversion$$anonfun$attempt$1.apply(Inversion.scala:30)
[error]     scala.util.Try$.apply(Try.scala:161)
[error]     com.twitter.bijection.Inversion$.attempt(Inversion.scala:30)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:97)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:71)
[error]     com.twitter.chill.KryoInjection$.invert(KryoInjection.scala:48)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:84)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:78)
[error]     org.specs.specification.LifeCycle$class.withCurrent(ExampleLifeCycle.scala:66)
[error]     org.specs.specification.Examples.withCurrent(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.ExampleExecution$$anonfun$3$$anonfun$apply$5.apply(ExampleLifeCycle.scala:219)
[error]     scala.Option.getOrElse(Option.scala:120)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:219)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:198)
[error]     org.specs.specification.ExampleExecution$$anonfun$2.apply(ExampleLifeCycle.scala:181)
[error]     org.specs.specification.ExampleExecution.execute(ExampleLifeCycle.scala:252)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.SpecificationExecutor$class.executeExample(SpecificationExecutor.scala:55)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleLifeCycle$class.executeExample(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.Examples.executeExamples(Examples.scala:80)
[error]     org.specs.specification.ExampleStructure$class.ownFailures(ExampleStructure.scala:58)
[error]     org.specs.specification.Examples.ownFailures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
[error]     scala.collection.AbstractTraversable.flatMap(Traversable.scala:105)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.failureAndErrors(HasResults.scala:61)
[error]     org.specs.specification.Examples.failureAndErrors(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.isOk(HasResults.scala:69)
[error]     org.specs.specification.Examples.isOk(Examples.scala:52)
[error]     org.specs.runner.NotifierRunner.reportSystem(NotifierRunner.scala:81)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:72)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:68)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     org.specs.runner.NotifierRunner.reportASpecification(NotifierRunner.scala:68)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:58)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:45)
[error]     org.specs.runner.Reporter$class.reportSpecs(Reporter.scala:195)
[error]     org.specs.runner.NotifierRunner.reportSpecs(NotifierRunner.scala:45)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:65)
[error]     sbt.TestRunner.delegateRun(TestFramework.scala:57)
[error]     sbt.TestRunner.run(TestFramework.scala:51)
[error]     sbt.TestRunner.runTest$1(TestFramework.scala:71)
[error]     sbt.TestRunner.run(TestFramework.scala:80)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:200)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$5.work(System.scala:71)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:18)
[error]     sbt.Execute.work(Execute.scala:238)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:160)
[error]     sbt.CompletionService$$anon$2.call(CompletionService.scala:30)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
[error]     java.lang.Thread.run(Thread.java:662)
[error]     Can not set final scala.xml.Node field org.specs.specification.ExampleDescription.toXhtml to scala.collection.immutable.$colon$colon (UnsafeFieldAccessorImpl.java:146)
[error]     sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:146)
[error]     sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:150)
[error]     sun.reflect.UnsafeQualifiedObjectFieldAccessorImpl.set(UnsafeQualifiedObjectFieldAccessorImpl.java:65)
[error]     java.lang.reflect.Field.set(Field.java:657)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:619)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:44)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:21)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:44)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:21)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.SerDeState.readClassAndObject(SerDeState.java:61)
[error]     com.twitter.chill.KryoInjectionInstance$$anonfun$invert$2.apply(KryoInjection.scala:97)
[error]     com.twitter.chill.KryoInjectionInstance$$anonfun$invert$2.apply(KryoInjection.scala:97)
[error]     com.twitter.bijection.Inversion$$anonfun$attempt$1.apply(Inversion.scala:30)
[error]     scala.util.Try$.apply(Try.scala:161)
[error]     com.twitter.bijection.Inversion$.attempt(Inversion.scala:30)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:97)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:71)
[error]     com.twitter.chill.KryoInjection$.invert(KryoInjection.scala:48)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:84)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:78)
[error]     org.specs.specification.LifeCycle$class.withCurrent(ExampleLifeCycle.scala:66)
[error]     org.specs.specification.Examples.withCurrent(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.ExampleExecution$$anonfun$3$$anonfun$apply$5.apply(ExampleLifeCycle.scala:219)
[error]     scala.Option.getOrElse(Option.scala:120)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:219)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:198)
[error]     org.specs.specification.ExampleExecution$$anonfun$2.apply(ExampleLifeCycle.scala:181)
[error]     org.specs.specification.ExampleExecution.execute(ExampleLifeCycle.scala:252)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.SpecificationExecutor$class.executeExample(SpecificationExecutor.scala:55)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleLifeCycle$class.executeExample(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.Examples.executeExamples(Examples.scala:80)
[error]     org.specs.specification.ExampleStructure$class.ownFailures(ExampleStructure.scala:58)
[error]     org.specs.specification.Examples.ownFailures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
[error]     scala.collection.AbstractTraversable.flatMap(Traversable.scala:105)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.failureAndErrors(HasResults.scala:61)
[error]     org.specs.specification.Examples.failureAndErrors(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.isOk(HasResults.scala:69)
[error]     org.specs.specification.Examples.isOk(Examples.scala:52)
[error]     org.specs.runner.NotifierRunner.reportSystem(NotifierRunner.scala:81)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:72)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:68)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     org.specs.runner.NotifierRunner.reportASpecification(NotifierRunner.scala:68)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:58)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:45)
[error]     org.specs.runner.Reporter$class.reportSpecs(Reporter.scala:195)
[error]     org.specs.runner.NotifierRunner.reportSpecs(NotifierRunner.scala:45)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:65)
[error]     sbt.TestRunner.delegateRun(TestFramework.scala:57)
[error]     sbt.TestRunner.run(TestFramework.scala:51)
[error]     sbt.TestRunner.runTest$1(TestFramework.scala:71)
[error]     sbt.TestRunner.run(TestFramework.scala:80)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:200)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$5.work(System.scala:71)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:18)
[error]     sbt.Execute.work(Execute.scala:238)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:160)
[error]     sbt.CompletionService$$anon$2.call(CompletionService.scala:30)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
[error]     java.lang.Thread.run(Thread.java:662)
[error]     Can not set final scala.xml.Node field org.specs.specification.ExampleDescription.toXhtml to scala.collection.immutable.$colon$colon (UnsafeFieldAccessorImpl.java:146)
[error]     sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:146)
[error]     sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:150)
[error]     sun.reflect.UnsafeQualifiedObjectFieldAccessorImpl.set(UnsafeQualifiedObjectFieldAccessorImpl.java:65)
[error]     java.lang.reflect.Field.set(Field.java:657)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:619)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:44)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:21)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:44)
[error]     com.twitter.chill.TraversableSerializer.read(Traversable.scala:21)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:605)
[error]     com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
[error]     com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:729)
[error]     com.twitter.chill.SerDeState.readClassAndObject(SerDeState.java:61)
[error]     com.twitter.chill.KryoInjectionInstance$$anonfun$invert$2.apply(KryoInjection.scala:97)
[error]     com.twitter.chill.KryoInjectionInstance$$anonfun$invert$2.apply(KryoInjection.scala:97)
[error]     com.twitter.bijection.Inversion$$anonfun$attempt$1.apply(Inversion.scala:30)
[error]     scala.util.Try$.apply(Try.scala:161)
[error]     com.twitter.bijection.Inversion$.attempt(Inversion.scala:30)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:97)
[error]     com.twitter.chill.KryoInjectionInstance.invert(KryoInjection.scala:71)
[error]     com.twitter.chill.KryoInjection$.invert(KryoInjection.scala:48)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:84)
[error]     com.twitter.chill.FunctionSerialization$$anonfun$6$$anonfun$apply$29.apply(FunctionSerialization.scala:78)
[error]     org.specs.specification.LifeCycle$class.withCurrent(ExampleLifeCycle.scala:66)
[error]     org.specs.specification.Examples.withCurrent(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.Examples$$anonfun$specifyExample$1.apply(Examples.scala:114)
[error]     org.specs.specification.ExampleExecution$$anonfun$3$$anonfun$apply$5.apply(ExampleLifeCycle.scala:219)
[error]     scala.Option.getOrElse(Option.scala:120)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.LifeCycle$$anonfun$executeExpectations$1.apply(ExampleLifeCycle.scala:90)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.LifeCycle$class.executeExpectations(ExampleLifeCycle.scala:90)
[error]     org.specs.specification.BaseSpecification.executeExpectations(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2$$anonfun$apply$3.apply(ExampleContext.scala:81)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3$$anonfun$apply$2.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$class.id$1(ExampleContext.scala:32)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$1.apply(ExampleContext.scala:33)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:81)
[error]     org.specs.specification.ExampleContext$$anonfun$executeExpectations$3.apply(ExampleContext.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleContext$class.executeExpectations(ExampleContext.scala:80)
[error]     org.specs.specification.Examples.executeExpectations(Examples.scala:52)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:219)
[error]     org.specs.specification.ExampleExecution$$anonfun$3.apply(ExampleLifeCycle.scala:198)
[error]     org.specs.specification.ExampleExecution$$anonfun$2.apply(ExampleLifeCycle.scala:181)
[error]     org.specs.specification.ExampleExecution.execute(ExampleLifeCycle.scala:252)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     org.specs.specification.SpecificationExecutor$$anonfun$executeExample$2.apply(SpecificationExecutor.scala:55)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.SpecificationExecutor$class.executeExample(SpecificationExecutor.scala:55)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.BaseSpecification.executeExample(BaseSpecification.scala:58)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.ExampleLifeCycle$$anonfun$executeExample$1.apply(ExampleLifeCycle.scala:125)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.ExampleLifeCycle$class.executeExample(ExampleLifeCycle.scala:125)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples.executeExample(Examples.scala:52)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     org.specs.specification.Examples$$anonfun$executeExamples$2.apply(Examples.scala:80)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.specification.Examples.executeExamples(Examples.scala:80)
[error]     org.specs.specification.ExampleStructure$class.ownFailures(ExampleStructure.scala:58)
[error]     org.specs.specification.Examples.ownFailures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     org.specs.specification.ExampleStructure$$anonfun$failures$1.apply(ExampleStructure.scala:64)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
[error]     scala.collection.AbstractTraversable.flatMap(Traversable.scala:105)
[error]     org.specs.specification.ExampleStructure$class.failures(ExampleStructure.scala:64)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.specification.Examples.failures(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.failureAndErrors(HasResults.scala:61)
[error]     org.specs.specification.Examples.failureAndErrors(Examples.scala:52)
[error]     org.specs.execute.HasResults$class.isOk(HasResults.scala:69)
[error]     org.specs.specification.Examples.isOk(Examples.scala:52)
[error]     org.specs.runner.NotifierRunner.reportSystem(NotifierRunner.scala:81)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:72)
[error]     org.specs.runner.NotifierRunner$$anonfun$reportASpecification$3.apply(NotifierRunner.scala:68)
[error]     scala.collection.immutable.List.foreach(List.scala:309)
[error]     org.specs.runner.NotifierRunner.reportASpecification(NotifierRunner.scala:68)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:58)
[error]     org.specs.runner.NotifierRunner.report(NotifierRunner.scala:45)
[error]     org.specs.runner.Reporter$class.reportSpecs(Reporter.scala:195)
[error]     org.specs.runner.NotifierRunner.reportSpecs(NotifierRunner.scala:45)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner$$anonfun$run$3.apply(TestInterfaceRunner.scala:72)
[error]     scala.Option.map(Option.scala:145)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:72)
[error]     org.specs.runner.TestInterfaceRunner.run(TestInterfaceRunner.scala:65)
[error]     sbt.TestRunner.delegateRun(TestFramework.scala:57)
[error]     sbt.TestRunner.run(TestFramework.scala:51)
[error]     sbt.TestRunner.runTest$1(TestFramework.scala:71)
[error]     sbt.TestRunner.run(TestFramework.scala:80)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10$$anonfun$apply$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:200)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.TestFramework$$anonfun$9$$anonfun$apply$9$$anonfun$10.apply(TestFramework.scala:188)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.Tests$$anonfun$makeParallel$1$$anonfun$apply$7.apply(Tests.scala:119)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$3$$anonfun$apply$2.apply(System.scala:47)
[error]     sbt.std.Transform$$anon$5.work(System.scala:71)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:232)
[error]     sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:18)
[error]     sbt.Execute.work(Execute.scala:238)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.Execute$$anonfun$submit$1.apply(Execute.scala:232)
[error]     sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:160)
[error]     sbt.CompletionService$$anon$2.call(CompletionService.scala:30)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
[error]     java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
[error]     java.util.concurrent.FutureTask.run(FutureTask.java:138)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
[error]     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
[error]     java.lang.Thread.run(Thread.java:662)
```
