### PR TITLE
(DO NOT MERGE) Demonstrate the comparator serialization error in scala 2.10 when using order.reverse

### DIFF
--- a/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
@@ -58,6 +58,12 @@ class PriorityQueueSpec extends Specification {
       qi.add(5)
       val qilist = toList(qi)
       toList(rt(kryo, qi)) must be_==(qilist)
+      // Now with a reverse ordering:
+      val qr = new java.util.PriorityQueue[(Int,Int)](3, ord.reverse)
+      qr.add((2,3))
+      qr.add((4,5))
+      val qrlist = toList(qr)
+      toList(rt(kryo, qr)) must be_==(qrlist)
     }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object ChillBuild extends Build {
 
   organization := "com.twitter",
 
-  scalaVersion := "2.9.3",
+  scalaVersion := "2.10.0",
 
   crossScalaVersions := Seq("2.9.3", "2.10.0"),
 


### PR DESCRIPTION
Per issue mentioned in https://github.com/twitter/scalding/issues/505 and  https://groups.google.com/forum/#!topic/cascading-user/ADeupogU6wM, I added a unit test here to demonstrate the issue. I feel this may be more related to a Scala problem...

When ord.reverse is used as a comparator in PriorityQueue, the outer alias in comparator (an Ordering object) in Scala 2.10 doesn't get serialized by Kryo. It seems that this field is considered as a synthetic field in Scala 2.10, so Kryo ignores this field during the serialization. However, this doesn't happen in Scala 2.9.3. Test passes in Scala 2.9.3.

Build should fail :-)
