### PR TITLE
fix (so to speak) for reverse ordering

### DIFF
--- a/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
@@ -58,6 +58,17 @@ class PriorityQueueSpec extends Specification {
       qi.add(5)
       val qilist = toList(qi)
       toList(rt(kryo, qi)) must be_==(qilist)
+      // Now with a reverse ordering
+      // Note that in chill-scala, synthetic fields are not ignored by default
+      // using the ScalaKryoInstantiator
+      val synthF = new com.esotericsoftware.kryo.serializers.FieldSerializer(kryo, ord.reverse.getClass)
+      synthF.setIgnoreSyntheticFields(false)
+      kryo.register(ord.reverse.getClass, synthF)
+      val qr = new java.util.PriorityQueue[(Int,Int)](3, ord.reverse)
+      qr.add((2,3))
+      qr.add((4,5))
+      val qrlist = toList(qr)
+      toList(rt(kryo, qr)) must be_==(qrlist)
     }
   }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable.ListMap
 import scala.collection.immutable.HashMap
 
 import scala.collection.mutable.{ArrayBuffer => MArrayBuffer, HashMap => MHashMap}
-
+import _root_.java.util.PriorityQueue
 import scala.collection.mutable
 /*
 * This is just a test case for Kryo to deal with. It should
@@ -216,6 +216,20 @@ class KryoSpec extends Specification with BaseProperties {
       byteBuffer.rewind()
       val opt2 = rich.fromByteBuffer(byteBuffer)
       opt2 must be_==(Option(obj))
+    }
+    "Handle Ordering.reverse" in {
+      // This is exercising the synthetic field serialization in 2.10
+      val ord = Ordering.fromLessThan[(Int,Int)] { (l, r) => l._1 < r._1 }
+      // Now with a reverse ordering:
+      val qr = new PriorityQueue[(Int,Int)](3, ord.reverse)
+      qr.add((2,3))
+      qr.add((4,5))
+      def toList[A](q: PriorityQueue[A]): List[A] = {
+        import scala.collection.JavaConverters._
+        q.iterator.asScala.toList
+      }
+      val qrlist = toList(qr)
+      toList(rt(qr)) must be_==(qrlist)
     }
   }
 }


### PR DESCRIPTION
Addresses #108 

There were two issues: 1) to serialize many scala objects, you need to not ignore synthetic fields. chill-scala was doing that, but scalding was not using that fix. 2) I added some tests to verify that serialization works when sythentic fields are handled correctly.
