### PR TITLE
Added serialisation for SortedSet and ListSet.

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -18,6 +18,8 @@ package com.twitter.chill
 
 import scala.collection.immutable.{
   BitSet,
+  ListSet,
+  SortedSet,
   ListMap,
   HashMap,
   Queue
@@ -92,6 +94,7 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       // wrapper array is abstract
       .forSubclass[WrappedArray[Any]](new WrappedArraySerializer[Any])
       .forSubclass[BitSet](new BitSetSerializer)
+      .forSubclass[SortedSet[Any]](new SortedSetSerializer)
       .forClass[Some[Any]](new SomeSerializer[Any])
       .forClass[Left[Any, Any]](new LeftSerializer[Any, Any])
       .forClass[Right[Any, Any]](new RightSerializer[Any, Any])
@@ -103,6 +106,7 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       // Vector is a final class
       .forTraversableClass(Vector.empty[Any])
       .forTraversableSubclass(IndexedSeq.empty[Any])
+      .forTraversableSubclass(ListSet.empty[Any])
       // specifically register small sets since Scala represents them differently
       .forConcreteTraversableClass(Set[Any]('a))
       .forConcreteTraversableClass(Set[Any]('a, 'b))

--- a/chill-scala/src/main/scala/com/twitter/chill/SortedSetSerializer.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/SortedSetSerializer.scala
@@ -1,0 +1,52 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.chill
+
+import scala.collection.immutable.SortedSet
+
+class SortedSetSerializer[T] extends KSerializer[SortedSet[T]] {
+  def write(kser: Kryo, out: Output, set: SortedSet[T]) {
+    //Write the size
+    out.writeInt(set.size, true)
+
+    // Write the ordering
+    kser.writeClassAndObject(out, set.ordering.asInstanceOf[AnyRef])
+    set.foreach { t  =>
+      val tRef = t.asInstanceOf[AnyRef]
+      kser.writeClassAndObject(out, tRef)
+      // After each intermediate object, flush
+      out.flush()
+    }
+  }
+
+  def read(kser: Kryo, in: Input, cls: Class[SortedSet[T]]): SortedSet[T] = {
+    val size = in.readInt(true)
+    val ordering = kser.readClassAndObject(in).asInstanceOf[Ordering[T]]
+
+    // Go ahead and be faster, and not as functional cool, and be mutable in here
+    var idx = 0
+    val builder = SortedSet.canBuildFrom[T](ordering)()
+    builder.sizeHint(size)
+
+    while (idx < size) {
+      val item = kser.readClassAndObject(in).asInstanceOf[T]
+      builder += item
+      idx += 1
+    }
+    builder.result()
+  }
+}

--- a/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
@@ -18,10 +18,7 @@ package com.twitter.chill
 
 import org.specs._
 
-import scala.collection.immutable.BitSet
-import scala.collection.immutable.ListMap
-import scala.collection.immutable.HashMap
-
+import scala.collection.immutable.{SortedSet, BitSet, ListSet, ListMap, HashMap}
 import scala.collection.mutable.{ArrayBuffer => MArrayBuffer, HashMap => MHashMap}
 import _root_.java.util.PriorityQueue
 import _root_.java.util.Locale
@@ -70,6 +67,8 @@ class KryoSpec extends Specification with BaseProperties {
                       MArrayBuffer(1,2,3,4,5),
                       List(Some(MHashMap(1->1, 2->2)), None, Some(MHashMap(3->4))),
                       Set(1,2,3,4,10),
+                      SortedSet[Long](),
+                      SortedSet(1L, 2L, 3L, 4L),
                       BitSet(),
                       BitSet((0 until 1000).map{ x : Int => x*x } : _*),
                       ListMap("good" -> 0.5, "bad" -> -1.0),
@@ -91,6 +90,22 @@ class KryoSpec extends Specification with BaseProperties {
       rtTest.zip(test).foreach { case (serdeser, orig) =>
         serdeser must be_==(orig)
       }
+    }
+    "round trip a SortedSet" in {
+      val a = SortedSet[Long]() // Test empty SortedSet
+      val b = SortedSet[Int](1,2) // Test small SortedSet
+      val c = SortedSet[Int](1,2,3,4,6,7,8,9,10)(Ordering.fromLessThan((x, y) => x > y)) // Test with different ordering
+      rt(a) must be_==(a)
+      rt(b) must be_==(b)
+      (rt(c) + 5) must be_==(c + 5)
+    }
+    "round trip a ListSet" in {
+      val a = ListSet[Long]() // Test empty SortedSet
+      val b = ListSet[Int](1,2) // Test small ListSet
+      val c = ListSet[Int](1,2,3,4,6,7,8,9,10)
+      rt(a) must be_==(a)
+      rt(b) must be_==(b)
+      (rt(c)) must be_==(c)
     }
     "handle trait with reference of self" in {
       var a= new ExampleUsingSelf{}


### PR DESCRIPTION
I added serialisation for immutable.SortedSet. I wanted to make it more generic but I couldn't figure out how to use CanBuildFrom and enforce the ordering. So any pointers on that would be welcome.

I threw in a fix for ListSet as well, since I was using it to test things.

Once this has been added, is it possible to propagate the fix to Scalding. I would like to use the CountMinSketch from Algebird which uses a SortedSet and currently that blows up.
