### PR TITLE
Enable getClass equality checking in tests

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -18,6 +18,7 @@ package com.twitter.chill
 
 import scala.collection.immutable.{
   BitSet,
+  HashSet,
   ListSet,
   NumericRange,
   Range,
@@ -129,12 +130,15 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forConcreteTraversableClass(Set[Any]('a, 'b))
       .forConcreteTraversableClass(Set[Any]('a, 'b, 'c))
       .forConcreteTraversableClass(Set[Any]('a, 'b, 'c, 'd))
-      .forConcreteTraversableClass(Set[Any]('a, 'b, 'c, 'd, 'e))
+      // default set implementation
+      .forConcreteTraversableClass(HashSet[Any]('a, 'b, 'c, 'd, 'e))
       // specifically register small maps since Scala represents them differently
       .forConcreteTraversableClass(Map[Any, Any]('a -> 'a))
       .forConcreteTraversableClass(Map[Any, Any]('a -> 'a, 'b -> 'b))
       .forConcreteTraversableClass(Map[Any, Any]('a -> 'a, 'b -> 'b, 'c -> 'c))
       .forConcreteTraversableClass(Map[Any, Any]('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd))
+      // default map implementation
+      .forConcreteTraversableClass(HashMap[Any, Any]('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd, 'e -> 'e))
       // The normal fields serializer works for ranges
       .registerClasses(Seq(classOf[Range.Inclusive],
                            classOf[NumericRange.Inclusive[_]],

--- a/chill-scala/src/test/scala/com/twitter/chill/BaseProperties.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/BaseProperties.scala
@@ -29,6 +29,16 @@ trait BaseProperties {
     pool.fromBytes(pool.toBytesWithClass(t)).asInstanceOf[T]
   }
 
+  def rtEquiv[T](t: T): Boolean = {
+    val serdeser = rt(t)
+    serdeser == t && serdeser.getClass.asInstanceOf[Class[Any]] == t.getClass.asInstanceOf[Class[Any]]
+  }
+
+  def rtEquiv[T](k: KryoInstantiator, t: T): Boolean = {
+    val serdeser = rt(k, t)
+    serdeser == t && serdeser.getClass.asInstanceOf[Class[Any]] == t.getClass.asInstanceOf[Class[Any]]
+  }
+
   // using java serialization. TODO: remove when this is shipped in bijection
   def jserialize[T <: Serializable](t: T): Array[Byte] = {
     val bos = new ByteArrayOutputStream


### PR DESCRIPTION
Not sure if removing the serializer for 5 item map concrete class is safe on all platforms/scala versions!

Perhaps the registrations for "small" maps should be generated automatically by looping over a range [1, 10], creating maps and only registering a serializer if the generated class is not the same as for some map of size > 10 (which will be a HashMap)
