### PR TITLE
Use shaded asm classes provided by Kryo.

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/ClosureCleaner.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ClosureCleaner.scala
@@ -37,8 +37,8 @@ import scala.collection.mutable.{Set => MSet, Map => MMap}
 
 import scala.annotation.tailrec
 
-import org.objectweb.asm.{ClassReader, MethodVisitor, Type, ClassVisitor}
-import org.objectweb.asm.Opcodes._
+import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.{ClassReader, MethodVisitor, Type, ClassVisitor}
+import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.Opcodes._
 
 /**
  * Copied from Spark, written by Matei Zaharia (matei@cs.berkeley.edu).

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -127,10 +127,7 @@ object ChillBuild extends Build {
     settings = sharedSettings
   ).settings(
     name := "chill",
-    previousArtifact := Some("com.twitter" % "chill_2.9.3" % "0.3.3"),
-    libraryDependencies ++= Seq(
-      "org.ow2.asm" % "asm-commons" % "4.0"
-    )
+    previousArtifact := Some("com.twitter" % "chill_2.9.3" % "0.3.3")
   ).dependsOn(chillJava)
 
   def isScala210x(scalaVersion: String) = scalaVersion match {


### PR DESCRIPTION
Recent versions of Kryo have bumped the asm dependency to 4.X
which conflicts with many other libraries (including some Hadoop
versions) that use asm 3.X.

Presumably to help with this, Kryo now bundles a shaded version
of asm inside of its own jars. This patch alters chill to use
Kryo's shaded asm package.

If Kryo stops shading this in future versions or changes
the shaded package name, this can easily be changed
accordingly or reverted to vanilla asm.
