### PR TITLE
updating akka dependency to 2.3.2

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -146,7 +146,7 @@ object ChillBuild extends Build {
       case false => Seq()
       case true => Seq(
       "com.typesafe" % "config" % "0.3.1",
-      "com.typesafe.akka" %% "akka-actor" % "2.3.2"
+      "com.typesafe.akka" %% "akka-actor" % "2.2.1" % "provided"
     )
   }
   lazy val chillAkka = module("akka").settings(


### PR DESCRIPTION
I'm not fully sure if akka 2.2 and akka 2.3 are fully binary compatible nor if chill-akka would have any problems with it. But we are on our way to upgrading to akka 2.3 and as this is one of our major dependencies (_thanks_), I wanted to make sure that it was okay too. And it was. So here you go.
