### PR TITLE
Remove a deprecation, that really should never have been there

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/config/ScalaMapConfig.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/config/ScalaMapConfig.scala
@@ -24,7 +24,6 @@ object ScalaMapConfig {
 /**
  * A simple config backed by an immutable Map
  */
-@deprecated("Class potentially unsafe, use ScalaAnyRefMapConfig", "0.3.6")
 class ScalaMapConfig(in: Map[String, String]) extends Config {
   private var conf = in
 


### PR DESCRIPTION
The comment above this is false, and it is useful.

It is the case that cascading uses untyped Maps in places, or `Map[AnyRef, AnyRef]` but that is no reason to not be more strict here.
