### PR TITLE
Make 2.10.4 the default, move to scalatest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: scala
 scala:
-  - 2.10.3
-  - 2.9.3
+  - 2.10.4

--- a/chill-akka/src/test/scala/com/twitter/chill/akka/AkkaTests.scala
+++ b/chill-akka/src/test/scala/com/twitter/chill/akka/AkkaTests.scala
@@ -16,15 +16,13 @@ limitations under the License.
 
 package com.twitter.chill.akka
 
-import org.specs._
+import org.scalatest._
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.serialization._
 import com.typesafe.config.ConfigFactory
 
-class AkkaTests extends Specification {
-
-  noDetailedDiffs() //Fixes issue for scala 2.9
+class AkkaTests extends WordSpec with Matchers {
 
   val system = ActorSystem("example", ConfigFactory.parseString("""
     akka.actor.serializers {
@@ -44,24 +42,24 @@ class AkkaTests extends Specification {
     "be selected for tuples" in {
       // Find the Serializer for it
       val serializer = serialization.findSerializerFor((1, 2, 3))
-      serializer.getClass.equals(classOf[AkkaSerializer]) must beTrue
+      serializer.getClass.equals(classOf[AkkaSerializer]) should equal(true)
     }
 
     "be selected for ActorRef" in {
       val serializer = serialization.findSerializerFor(system.actorFor("akka://test-system/test-actor"))
-      serializer.getClass.equals(classOf[AkkaSerializer]) must beTrue
+      serializer.getClass.equals(classOf[AkkaSerializer]) should equal(true)
     }
 
     "serialize and deserialize ActorRef successfully" in {
       val actorRef = system.actorFor("akka://test-system/test-actor")
 
       val serialized = serialization.serialize(actorRef)
-      serialized.isSuccess must beTrue
+      serialized.isSuccess should equal(true)
 
       val deserialized = serialization.deserialize(serialized.get, classOf[ActorRef])
-      deserialized.isSuccess must beTrue
+      deserialized.isSuccess should equal(true)
 
-      deserialized.get.equals(actorRef) must beTrue
+      deserialized.get.equals(actorRef) should equal(true)
     }
 
   }

--- a/chill-algebird/src/test/scala/com/twitter/chill/algebird/AlgebirdSerializersSpec.scala
+++ b/chill-algebird/src/test/scala/com/twitter/chill/algebird/AlgebirdSerializersSpec.scala
@@ -18,9 +18,9 @@ package com.twitter.chill.algebird
 
 import com.twitter.chill.{ KSerializer, ScalaKryoInstantiator, KryoPool }
 import com.twitter.algebird.{ AveragedValue, DecayedValue, HyperLogLogMonoid, MomentsGroup, AdaptiveVector }
-import org.specs.Specification
+import org.scalatest._
 
-class AlgebirdSerializersSpec extends Specification {
+class AlgebirdSerializersSpec extends WordSpec with Matchers {
   val kryo = {
     val inst = () => {
       val newK = (new ScalaKryoInstantiator).newKryo
@@ -36,13 +36,14 @@ class AlgebirdSerializersSpec extends Specification {
     //println("bytes size : " + bytes.size)
     //println("bytes: " + new String(bytes, "UTF-8"))
     val result = kryo.fromBytes(bytes).asInstanceOf[X]
-    result must_== x
+    result should equal(x)
+
   }
 
   def roundtripNoEq[X](x: X)(f: X => Any) {
     val bytes = kryo.toBytesWithClass(x)
     val result = kryo.fromBytes(bytes).asInstanceOf[X]
-    f(result) must_== f(x)
+    f(result) should equal(f(x))
   }
 
   "kryo with AlgebirdRegistrar" should {

--- a/chill-avro/src/test/scala/com/twitter/chill/avro/AvroSerializerSpec.scala
+++ b/chill-avro/src/test/scala/com/twitter/chill/avro/AvroSerializerSpec.scala
@@ -14,7 +14,7 @@ limitations under the License.
 */
 package com.twitter.chill.avro
 
-import org.specs.Specification
+import org.scalatest._
 import com.twitter.chill.{ KSerializer, ScalaKryoInstantiator, KryoPool }
 import avro.FiscalRecord
 import org.apache.avro.generic.GenericRecordBuilder
@@ -25,7 +25,7 @@ import org.apache.avro.generic.GenericData.Record
  * @author Mansur Ashraf
  * @since 2/9/14.
  */
-object AvroSerializerSpec extends Specification {
+object AvroSerializerSpec extends WordSpec with Matchers {
 
   def getKryo[T: Manifest](k: KSerializer[T]) = {
     val inst = {
@@ -54,7 +54,7 @@ object AvroSerializerSpec extends Specification {
       val kryo = getKryo(AvroSerializer.SpecificRecordSerializer[FiscalRecord])
       val bytes = kryo.toBytesWithClass(testRecord)
       val result = kryo.fromBytes(bytes).asInstanceOf[FiscalRecord]
-      testRecord must_== result
+      testRecord should equal(result)
     }
   }
 
@@ -63,7 +63,7 @@ object AvroSerializerSpec extends Specification {
       val kryo = getKryo(AvroSerializer.SpecificRecordBinarySerializer[FiscalRecord])
       val bytes = kryo.toBytesWithClass(testRecord)
       val result = kryo.fromBytes(bytes).asInstanceOf[FiscalRecord]
-      testRecord must_== result
+      testRecord should equal(result)
     }
   }
 
@@ -72,7 +72,7 @@ object AvroSerializerSpec extends Specification {
       val kryo = getKryo(AvroSerializer.SpecificRecordJsonSerializer[FiscalRecord](FiscalRecord.SCHEMA$))
       val bytes = kryo.toBytesWithClass(testRecord)
       val result = kryo.fromBytes(bytes).asInstanceOf[FiscalRecord]
-      testRecord must_== result
+      testRecord should equal(result)
     }
   }
 
@@ -81,13 +81,13 @@ object AvroSerializerSpec extends Specification {
       val kryo = getKryo(AvroSerializer.GenericRecordSerializer[Record]())
       val userBytes = kryo.toBytesWithClass(user)
       val userResult = kryo.fromBytes(userBytes).asInstanceOf[Record]
-      userResult.get("name").toString must_== "Jeff"
-      userResult.get("ID") must_== 1
-      user.toString must_== userResult.toString
+      userResult.get("name").toString should equal("Jeff")
+      userResult.get("ID") should equal(1)
+      user.toString should equal(userResult.toString)
 
       val testRecordBytes = kryo.toBytesWithClass(testRecord)
       val testRecordResult = kryo.fromBytes(testRecordBytes).asInstanceOf[FiscalRecord]
-      testRecord.toString must_== testRecordResult.toString
+      testRecord.toString should equal(testRecordResult.toString)
     }
   }
 }

--- a/chill-bijection/src/test/scala/com/twitter/chill/CustomSerializationSpec.scala
+++ b/chill-bijection/src/test/scala/com/twitter/chill/CustomSerializationSpec.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.chill
 
-import org.specs._
+import org.scalatest._
 
 import com.twitter.bijection.Bijection
 
@@ -29,7 +29,7 @@ object Globals {
   var temp = false
 }
 
-class CustomSerializationSpec extends Specification with BaseProperties {
+class CustomSerializationSpec extends WordSpec with Matchers with BaseProperties {
   "Custom KryoSerializers and KryoDeserializers" should {
     "serialize objects that have registered serialization" in {
 
@@ -66,7 +66,7 @@ class CustomSerializationSpec extends Specification with BaseProperties {
       val point = Point(5, 6)
       val coloredPoint = ColoredPoint(color, point)
 
-      rt(myInst, coloredPoint) must_== coloredPoint
+      rt(myInst, coloredPoint) should equal(coloredPoint)
     }
     "use bijections" in {
       implicit val bij = Bijection.build[TestCaseClassForSerialization, (String, Int)] { s =>
@@ -78,18 +78,18 @@ class CustomSerializationSpec extends Specification with BaseProperties {
           .newKryo
           .forClassViaBijection[TestCaseClassForSerialization, (String, Int)]
       }
-      rt(inst, TestCaseClassForSerialization("hey", 42)) must be_==(TestCaseClassForSerialization("hey", 42))
+      rt(inst, TestCaseClassForSerialization("hey", 42)) should equal(TestCaseClassForSerialization("hey", 42))
     }
     "Make sure KryoInjection and instances are Java Serializable" in {
       val ki = jrt(KryoInjection)
-      ki.invert(ki(1)).get must be_==(1)
+      ki.invert(ki(1)).get should equal(1)
       val kii = jrt(KryoInjection.instance(new ScalaKryoInstantiator))
-      kii.invert(kii(1)).get must be_==(1)
+      kii.invert(kii(1)).get should equal(1)
     }
   }
   "KryoInjection handle an example with closure to function" in {
     val x = rt(() => Foo.Bar)
-    x() must be_==(Foo.Bar)
+    x() should equal(Foo.Bar)
   }
   "handle a closure to println" in {
     Globals.temp = false
@@ -101,6 +101,6 @@ class CustomSerializationSpec extends Specification with BaseProperties {
     })
     val inv = KryoInjection.invert(bytes)
     inv.get.asInstanceOf[() => Unit].apply()
-    Globals.temp must be_==(true)
+    Globals.temp should equal(true)
   }
 }

--- a/chill-hadoop/src/test/scala/com/twitter/chill/hadoop/HadoopTests.scala
+++ b/chill-hadoop/src/test/scala/com/twitter/chill/hadoop/HadoopTests.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.chill.hadoop
 
-import org.specs._
+import org.scalatest._
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -37,9 +37,7 @@ class StdKryoInstantiator extends KryoInstantiator {
     k
   }
 }
-class HadoopTests extends Specification {
-  noDetailedDiffs() //Fixes issue for scala 2.9
-
+class HadoopTests extends WordSpec with Matchers {
   def rt[A <: AnyRef](k: KryoSerialization, a: A): A = {
     val out = new BAOut
     val cls = a.getClass.asInstanceOf[Class[AnyRef]]
@@ -65,7 +63,7 @@ class HadoopTests extends Specification {
       val ks = new KryoSerialization(conf)
       Seq(classOf[List[_]], classOf[Int], this.getClass).forall { cls =>
         ks.accept(cls)
-      } must beTrue
+      } should equal(true)
     }
     "Serialize a list of random things" in {
       val conf = new Configuration
@@ -76,7 +74,7 @@ class HadoopTests extends Specification {
       val ks = new KryoSerialization(conf)
       val things = List(1.asInstanceOf[AnyRef], "hey", (1, 2))
 
-      things.map { rt(ks, _) } must be_==(things)
+      things.map { rt(ks, _) } should equal(things)
     }
   }
 }

--- a/chill-java/src/test/scala/com/twitter/chill/config/ConfiguredInstantiatorTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/config/ConfiguredInstantiatorTest.scala
@@ -16,28 +16,28 @@ limitations under the License.
 
 package com.twitter.chill.config
 
-import org.specs._
+import org.scalatest._
 
 import com.twitter.chill._
 import com.esotericsoftware.kryo.Kryo
 
 class TestInst extends KryoInstantiator { override def newKryo = new Kryo }
 
-class ReflectingInstantiatorTest extends Specification {
+class ReflectingInstantiatorTest extends WordSpec with Matchers {
   "A ConfiguredInstantiator" should {
     "work with a reflected instantiator" in {
       val conf = new JavaMapConfig
       ConfiguredInstantiator.setReflect(conf, classOf[TestInst])
-      conf.get(ConfiguredInstantiator.KEY) must be_==(classOf[TestInst].getName)
+      conf.get(ConfiguredInstantiator.KEY) should equal(classOf[TestInst].getName)
       val cci = new ConfiguredInstantiator(conf)
-      cci.getDelegate.getClass == classOf[TestInst] must beTrue
+      cci.getDelegate.getClass should equal(classOf[TestInst])
     }
     "work with a serialized instantiator" in {
       val conf = new JavaMapConfig
       ConfiguredInstantiator.setSerialized(conf, new TestInst)
       val cci = new ConfiguredInstantiator(conf)
       // Here is the only assert:
-      cci.getDelegate.getClass == classOf[TestInst] must beTrue
+      cci.getDelegate.getClass should equal(classOf[TestInst])
     }
   }
 }

--- a/chill-java/src/test/scala/com/twitter/chill/java/LocaleTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/LocaleTest.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.chill.java
 
-import org.specs._
+import org.scalatest._
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -26,8 +26,7 @@ import org.objenesis.strategy.StdInstantiatorStrategy
 
 import _root_.java.util.Locale
 
-class LocaleSpec extends Specification {
-  noDetailedDiffs() //Fixes issue for scala 2.9
+class LocaleSpec extends WordSpec with Matchers {
 
   def rt[A](k: Kryo, a: A): A = {
     val out = new Output(1000, -1)
@@ -45,7 +44,7 @@ class LocaleSpec extends Specification {
       LocaleSerializer.registrar()(kryo)
 
       Locale.getAvailableLocales.foreach { l =>
-        rt(kryo, l) must be_==(l)
+        rt(kryo, l) should equal(l)
       }
     }
   }

--- a/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.chill.java
 
-import org.specs._
+import org.scalatest._
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -24,8 +24,7 @@ import com.esotericsoftware.kryo.io.Output;
 
 import org.objenesis.strategy.StdInstantiatorStrategy
 
-class PriorityQueueSpec extends Specification {
-  noDetailedDiffs() //Fixes issue for scala 2.9
+class PriorityQueueSpec extends WordSpec with Matchers {
 
   def rt[A](k: Kryo, a: A): A = {
     val out = new Output(1000, -1)
@@ -49,15 +48,15 @@ class PriorityQueueSpec extends Specification {
         q.iterator.asScala.toList
       val qlist = toList(q)
       val newQ = rt(kryo, q)
-      toList(newQ) must be_==(qlist)
+      toList(newQ) should equal(qlist)
       newQ.add((1, 1))
-      newQ.add((2, 1)) must beTrue
+      newQ.add((2, 1)) should equal(true)
       // Now without an ordering:
       val qi = new java.util.PriorityQueue[Int](3)
       qi.add(2)
       qi.add(5)
       val qilist = toList(qi)
-      toList(rt(kryo, qi)) must be_==(qilist)
+      toList(rt(kryo, qi)) should equal(qilist)
       // Now with a reverse ordering
       // Note that in chill-scala, synthetic fields are not ignored by default
       // using the ScalaKryoInstantiator
@@ -68,7 +67,7 @@ class PriorityQueueSpec extends Specification {
       qr.add((2, 3))
       qr.add((4, 5))
       val qrlist = toList(qr)
-      toList(rt(kryo, qr)) must be_==(qrlist)
+      toList(rt(kryo, qr)) should equal(qrlist)
     }
   }
 }

--- a/chill-protobuf/src/test/scala/com/twitter/chill/protobuf/ProtobufTest.scala
+++ b/chill-protobuf/src/test/scala/com/twitter/chill/protobuf/ProtobufTest.scala
@@ -23,9 +23,9 @@ import com.esotericsoftware.kryo.Kryo
 
 import com.google.protobuf.Message
 
-import org.specs._
+import org.scalatest._
 
-class ProtobufTest extends Specification {
+class ProtobufTest extends WordSpec with Matchers {
   def buildFatigueCount(target: Long, id: Long, count: Int, recentClicks: List[Long]) = {
     val bldr = FatigueCount.newBuilder()
       .setTargetId(target)
@@ -45,11 +45,11 @@ class ProtobufTest extends Specification {
       }
     })
 
-    kpool.deepCopy(buildFatigueCount(12L, -1L, 42, List(1L, 2L))) must be_==(
+    kpool.deepCopy(buildFatigueCount(12L, -1L, 42, List(1L, 2L))) should equal(
       buildFatigueCount(12L, -1L, 42, List(1L, 2L)))
 
     // Without the protobuf serializer, this fails:
     val kpoolBusted = KryoPool.withByteArrayOutputStream(1, new KryoInstantiator)
-    kpoolBusted.deepCopy(buildFatigueCount(12L, -1L, 42, List(1L, 2L))) must throwA[Exception]
+    an[Exception] should be thrownBy (kpoolBusted.deepCopy(buildFatigueCount(12L, -1L, 42, List(1L, 2L))))
   }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/ClosureCleanerSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/ClosureCleanerSpec.scala
@@ -16,9 +16,9 @@ limitations under the License.
 
 package com.twitter.chill
 
-import org.specs._
+import org.scalatest._
 
-class ClosureCleanerSpec extends Specification {
+class ClosureCleanerSpec extends WordSpec with Matchers {
   def debug(x: AnyRef) {
     println(x.getClass)
     println(x.getClass.getDeclaredFields.map { _.toString }.mkString("  "))
@@ -27,19 +27,19 @@ class ClosureCleanerSpec extends Specification {
     "clean normal objects" in {
       val myList = List(1, 2, 3)
       ClosureCleaner(myList)
-      myList must be_==(List(1, 2, 3))
+      myList should equal(List(1, 2, 3))
     }
     "clean actual closures" in {
       val myFun = { x: Int => x * 2 }
 
       ClosureCleaner(myFun)
-      myFun(1) must be_==(2)
-      myFun(2) must be_==(4)
+      myFun(1) should equal(2)
+      myFun(2) should equal(4)
 
       case class Test(x: Int)
       val t = Test(3)
       ClosureCleaner(t)
-      t must be_==(Test(3))
+      t should equal(Test(3))
     }
 
     "handle outers with constructors" in {
@@ -54,18 +54,18 @@ class ClosureCleanerSpec extends Specification {
       //debug(fn)
       //println(ClosureCleaner.getOutersOf(fn))
       ClosureCleaner(fn)
-      fn("hey") must be_==(20)
+      fn("hey") should equal(20)
     }
     "Handle functions in traits" in {
       val fn = BaseFns2.timesByMult
       ClosureCleaner(fn)
-      fn(10) must be_==(50)
+      fn(10) should equal(50)
     }
     "Handle captured vals" in {
       val answer = 42
       val fn = { x: Int => answer * x }
       ClosureCleaner(fn)
-      fn(10) must be_==(420)
+      fn(10) should equal(420)
     }
   }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/ExternalizerSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/ExternalizerSpec.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.chill
 
-import org.specs._
+import org.scalatest._
 
 import scala.collection.immutable.BitSet
 import scala.collection.immutable.ListMap
@@ -29,10 +29,7 @@ import scala.collection.mutable
 
 class ExtSomeRandom(val x: Int)
 
-class ExternalizerSpec extends Specification with BaseProperties {
-
-  noDetailedDiffs() //Fixes issue for scala 2.9
-
+class ExternalizerSpec extends WordSpec with Matchers with BaseProperties {
   def getKryo = KryoSerializer.registered.newKryo
 
   "KryoSerializers and KryoDeserializers" should {
@@ -41,23 +38,20 @@ class ExternalizerSpec extends Specification with BaseProperties {
       val ext = Externalizer(l)
       l(1) = ext
 
-      ext.javaWorks must be_==(true)
+      ext.javaWorks should equal(true)
     }
     "Externalizer handle circular references with Java2" in {
       val l = Array[AnyRef](null)
       val ext = Externalizer(l)
       l.update(0, ext) // make a loop
-      (l(0) eq ext) must beTrue
-      ext.javaWorks must be_==(true)
-      //jrt(ext).get.toList must_==(l.toList)
-      // Try Kryo also
-      //rt(ext).get.toList must_==(l.toList)
+      (l(0) eq ext) should equal(true)
+      ext.javaWorks should equal(true)
 
       val nonJavaSer = Array(new ExtSomeRandom(2))
-      jrt(nonJavaSer) must throwA[Exception]
+      an[Exception] should be thrownBy jrt(nonJavaSer)
       val ext2 = Externalizer(nonJavaSer)
-      jrt(ext2).get(0).x must be_==(2)
-      ext2.javaWorks must beFalse
+      jrt(ext2).get(0).x should equal(2)
+      ext2.javaWorks should equal(false)
 
     }
 
@@ -67,9 +61,9 @@ class ExternalizerSpec extends Specification with BaseProperties {
       val ext3 = Externalizer(l3)
       l3.update(0, ext3) // make a loop
       l3.update(1, new ExtSomeRandom(3)) // make a loop
-      (l3(0) eq ext3) must beTrue
-      ext3.javaWorks must be_==(false)
-      (jrt(ext3).get)(1).asInstanceOf[ExtSomeRandom].x must_== (l3(1).asInstanceOf[ExtSomeRandom].x)
+      (l3(0) eq ext3) should equal(true)
+      ext3.javaWorks should equal(false)
+      (jrt(ext3).get)(1).asInstanceOf[ExtSomeRandom].x should equal (l3(1).asInstanceOf[ExtSomeRandom].x)
     }
 
     "Externalizer circular reference with scala tuples(java and kryo Serializable" in {
@@ -77,10 +71,10 @@ class ExternalizerSpec extends Specification with BaseProperties {
       val ext4 = Externalizer(l4)
       l4.update(0, ext4) // make a loop
       l4.update(1, (3, 7)) // make a loop
-      (l4(0) eq ext4) must beTrue
-      ext4.javaWorks must be_==(true)
-      (rt(ext4).get)(1) must_== (l4(1))
-      (jrt(ext4).get)(1) must_== (l4(1))
+      (l4(0) eq ext4) should equal(true)
+      ext4.javaWorks should equal(true)
+      (rt(ext4).get)(1) should equal (l4(1))
+      (jrt(ext4).get)(1) should equal (l4(1))
     }
 
     "Externalizer handle circular references with non Kryo Serializable members" in {
@@ -88,10 +82,10 @@ class ExternalizerSpec extends Specification with BaseProperties {
       val ext4 = Externalizer(l4)
       l4.update(0, ext4) // make a loop
       l4.update(1, new Locale("en")) // make a loop
-      (l4(0) eq ext4) must beTrue
-      ext4.javaWorks must be_==(true)
+      (l4(0) eq ext4) should equal(true)
+      ext4.javaWorks should equal(true)
       (rt(new EmptyScalaKryoInstantiator(), ext4).get)(1)
-      (jrt(ext4).get)(1) must_== (l4(1))
+      (jrt(ext4).get)(1) should equal (l4(1))
     }
   }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/FunctionSerialization.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/FunctionSerialization.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.chill
 
-import org.specs._
+import org.scalatest._
 
 import com.esotericsoftware.kryo.serializers.FieldSerializer
 
@@ -38,28 +38,26 @@ object BaseFns2 extends AwesomeFn2 {
   def mult = 5
 }
 
-class FunctionSerialization extends Specification with BaseProperties {
-  noDetailedDiffs() //Fixes issue for scala 2.9
-
+class FunctionSerialization extends WordSpec with Matchers with BaseProperties {
   "Serialize objects with Fns" should {
     "fn calling" in {
-      //rt(fn).apply(4) must be_==(8)
+      //rt(fn).apply(4) should equal(8)
       // In the object:
-      rt(BaseFns.myfun2).apply(4) must be_==(16)
+      rt(BaseFns.myfun2).apply(4) should equal(16)
 
       // Inherited from the trait:
-      rt(BaseFns.myfun).apply(4) must be_==(8)
+      rt(BaseFns.myfun).apply(4) should equal(8)
     }
     "roundtrip the object" in {
-      rt(BaseFns) must be_==(BaseFns)
+      rt(BaseFns) should equal(BaseFns)
     }
     "Handle traits with abstract vals/def" in {
       val bf2 = rt(BaseFns2)
-      (bf2 eq BaseFns2) must beTrue
-      bf2 must be_==(BaseFns2)
-      bf2.timesByMult(10) must be_==(50)
+      (bf2 eq BaseFns2) should equal(true)
+      bf2 should equal(BaseFns2)
+      bf2.timesByMult(10) should equal(50)
       val rtTBM = rt(BaseFns2.timesByMult)
-      rtTBM.apply(10) must be_==(50)
+      rtTBM.apply(10) should equal(50)
     }
   }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
@@ -16,8 +16,8 @@ limitations under the License.
 
 package com.twitter.chill
 
-import org.specs._
-import org.specs.matcher.Matcher
+import org.scalatest._
+import org.scalatest.matchers.{ Matcher, MatchResult }
 
 import scala.collection.immutable.{ SortedSet, BitSet, ListSet, HashSet, SortedMap, ListMap, HashMap }
 import scala.collection.mutable.{ ArrayBuffer => MArrayBuffer, BitSet => MBitSet, HashMap => MHashMap }
@@ -51,12 +51,10 @@ trait ExampleUsingSelf { self =>
 
 case class Foo(m1: Map[String, Int], m2: Map[String, Seq[String]])
 
-class KryoSpec extends Specification with BaseProperties {
-
-  noDetailedDiffs() //Fixes issue for scala 2.9
+class KryoSpec extends WordSpec with Matchers with BaseProperties {
 
   def roundtrip[T] = new Matcher[T] {
-    def apply(t: => T) = (rtEquiv(t), "successfull serialization roundtrip for " + t, "failed serialization roundtrip for " + t)
+    def apply(t: T) = MatchResult(rtEquiv(t), "successfull serialization roundtrip for " + t, "failed serialization roundtrip for " + t)
   }
 
   def getKryo = KryoSerializer.registered.newKryo
@@ -106,39 +104,39 @@ class KryoSpec extends Specification with BaseProperties {
         'hai)
         .asInstanceOf[List[AnyRef]]
 
-      test.foreach { _ must roundtrip }
+      test.foreach { _ should roundtrip }
     }
     "round trip a SortedSet" in {
       val a = SortedSet[Long]() // Test empty SortedSet
       val b = SortedSet[Int](1, 2) // Test small SortedSet
       val c = SortedSet[Int](1, 2, 3, 4, 6, 7, 8, 9, 10)(Ordering.fromLessThan((x, y) => x > y)) // Test with different ordering
-      a must roundtrip
-      b must roundtrip
-      c must roundtrip
-      (rt(c) + 5) must be_==(c + 5)
+      a should roundtrip
+      b should roundtrip
+      c should roundtrip
+      (rt(c) + 5) should equal(c + 5)
     }
     "round trip a ListSet" in {
       val a = ListSet[Long]() // Test empty SortedSet
       val b = ListSet[Int](1, 2) // Test small ListSet
       val c = ListSet[Int](1, 2, 3, 4, 6, 7, 8, 9, 10)
-      a must roundtrip
-      b must roundtrip
-      c must roundtrip
+      a should roundtrip
+      b should roundtrip
+      c should roundtrip
     }
     "handle trait with reference of self" in {
       var a = new ExampleUsingSelf {}
       var b = rt(a.addOne)
-      b.count must be_==(1)
+      b.count should equal(1)
     }
     "handle manifests" in {
-      manifest[Int] must roundtrip
-      manifest[(Int, Int)] must roundtrip
-      manifest[Array[Int]] must roundtrip
+      manifest[Int] should roundtrip
+      manifest[(Int, Int)] should roundtrip
+      manifest[Array[Int]] should roundtrip
     }
     "handle arrays" in {
       def arrayRT[T](arr: Array[T]) {
         // Array doesn't have a good equals
-        rt(arr).toList must be_==(arr.toList)
+        rt(arr).toList should equal(arr.toList)
       }
       arrayRT(Array(0))
       arrayRT(Array(0.1))
@@ -152,61 +150,61 @@ class KryoSpec extends Specification with BaseProperties {
         Array((1, 1), (2, 2), (3, 3)).toSeq,
         Array((1.0, 1.0), (2.0, 2.0)).toSeq,
         Array((1.0, "1.0"), (2.0, "2.0")).toSeq)
-      tests.foreach { _ must roundtrip }
+      tests.foreach { _ should roundtrip }
     }
     "handle lists of lists" in {
-      List(("us", List(1)), ("jp", List(3, 2)), ("gb", List(3, 1))) must roundtrip
+      List(("us", List(1)), ("jp", List(3, 2)), ("gb", List(3, 1))) should roundtrip
     }
     "handle scala singletons" in {
-      List(Nil, None) must roundtrip
-      None must roundtrip
-      (rt(None) eq None) must beTrue
+      List(Nil, None) should roundtrip
+      None should roundtrip
+      (rt(None) eq None) should equal(true)
     }
     "serialize a giant list" in {
       val bigList = (1 to 100000).toList
       val list2 = rt(bigList)
-      list2.size must be_==(bigList.size)
+      list2.size should equal(bigList.size)
       //Specs, it turns out, also doesn't deal with giant lists well:
-      list2.zip(bigList).foreach { tup => tup._1 must be_==(tup._2) }
+      list2.zip(bigList).foreach { tup => tup._1 should equal(tup._2) }
     }
     "handle scala enums" in {
-      WeekDay.values.foreach { _ must roundtrip }
+      WeekDay.values.foreach { _ should roundtrip }
     }
     "handle asJavaIterable" in {
       val col = scala.collection.JavaConversions.asJavaIterable(Seq(12345))
-      col must roundtrip
+      col should roundtrip
     }
     "use java serialization" in {
       val kinst = { () => getKryo.javaForClass[TestCaseClassForSerialization] }
-      rtEquiv(kinst, TestCaseClassForSerialization("hey", 42)) must beTrue
+      rtEquiv(kinst, TestCaseClassForSerialization("hey", 42)) should equal(true)
     }
     "work with Meatlocker" in {
       val l = List(1, 2, 3)
       val ml = MeatLocker(l)
-      jrt(ml).get must_== (l)
+      jrt(ml).get should equal (l)
     }
     "work with Externalizer" in {
       val l = List(1, 2, 3)
       val ext = Externalizer(l)
-      ext.javaWorks must be_==(true)
-      jrt(ext).get must_== (l)
+      ext.javaWorks should equal(true)
+      jrt(ext).get should equal (l)
     }
     "work with Externalizer with non-java-ser" in {
       val l = new SomeRandom(3)
       val ext = Externalizer(l)
-      ext.javaWorks must be_==(false)
-      jrt(ext).get.x must_== (l.x)
+      ext.javaWorks should equal(false)
+      jrt(ext).get.x should equal (l.x)
     }
     "Externalizer can RT with Kryo" in {
       val l = new SomeRandom(10)
       val ext = Externalizer(l)
-      rt(ext).get.x must_== (l.x)
+      rt(ext).get.x should equal (l.x)
     }
     "handle Regex" in {
       val test = """\bhilarious""".r
       val roundtripped = rt(test)
-      roundtripped.pattern.pattern must be_==(test.pattern.pattern)
-      roundtripped.findFirstIn("hilarious").isDefined must beTrue
+      roundtripped.pattern.pattern should equal(test.pattern.pattern)
+      roundtripped.findFirstIn("hilarious").isDefined should equal(true)
     }
     "handle small immutable maps when registration is required" in {
       val inst = { () =>
@@ -219,7 +217,7 @@ class KryoSpec extends Specification with BaseProperties {
       val m3 = Map('a -> 'a, 'b -> 'b, 'c -> 'c)
       val m4 = Map('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd)
       val m5 = Map('a -> 'a, 'b -> 'b, 'c -> 'c, 'd -> 'd, 'e -> 'e)
-      Seq(m1, m2, m3, m4, m5).foreach { rtEquiv(inst, _) must beTrue }
+      Seq(m1, m2, m3, m4, m5).foreach { rtEquiv(inst, _) should equal(true) }
     }
     "handle small immutable sets when registration is required" in {
       val inst = { () =>
@@ -232,7 +230,7 @@ class KryoSpec extends Specification with BaseProperties {
       val s3 = Set('a, 'b, 'c)
       val s4 = Set('a, 'b, 'c, 'd)
       val s5 = Set('a, 'b, 'c, 'd, 'e)
-      Seq(s1, s2, s3, s4, s5).foreach { rtEquiv(inst, _) must beTrue }
+      Seq(s1, s2, s3, s4, s5).foreach { rtEquiv(inst, _) should equal(true) }
     }
     "handle nested mutable maps" in {
       val inst = { () =>
@@ -249,7 +247,7 @@ class KryoSpec extends Specification with BaseProperties {
         1 -> mutable.Set("name3", "name4", "name1", "name2"),
         0 -> mutable.Set(1, 2, 3, 4))
 
-      rtEquiv(inst, obj0) must beTrue
+      rtEquiv(inst, obj0) should equal(true)
     }
     "deserialize InputStream" in {
       val obj = Seq(1, 2, 3)
@@ -261,12 +259,12 @@ class KryoSpec extends Specification with BaseProperties {
       val rich = new RichKryo(kryo)
 
       val opt1 = rich.fromInputStream(inputStream)
-      opt1 must be_==(Option(obj))
+      opt1 should equal(Option(obj))
 
       // Test again to make sure it still works
       inputStream.reset()
       val opt2 = rich.fromInputStream(inputStream)
-      opt2 must be_==(Option(obj))
+      opt2 should equal(Option(obj))
     }
     "deserialize ByteBuffer" in {
       val obj = Seq(1, 2, 3)
@@ -278,12 +276,12 @@ class KryoSpec extends Specification with BaseProperties {
       val rich = new RichKryo(kryo)
 
       val opt1 = rich.fromByteBuffer(byteBuffer)
-      opt1 must be_==(Option(obj))
+      opt1 should equal(Option(obj))
 
       // Test again to make sure it still works
       byteBuffer.rewind()
       val opt2 = rich.fromByteBuffer(byteBuffer)
-      opt2 must be_==(Option(obj))
+      opt2 should equal(Option(obj))
     }
     "Handle Ordering.reverse" in {
       // This is exercising the synthetic field serialization in 2.10
@@ -297,22 +295,22 @@ class KryoSpec extends Specification with BaseProperties {
         q.iterator.asScala.toList
       }
       val qrlist = toList(qr)
-      toList(rt(qr)) must be_==(qrlist)
+      toList(rt(qr)) should equal(qrlist)
     }
     "Ranges should be fixed size" in {
       val MAX_RANGE_SIZE = 188 // what seems to be needed.
-      serialize((1 to 10000)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1 to 10000 by 2)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1 until 10000)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1 until 10000 by 2)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1L to 10000L)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1L to 10000L by 2L)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1L until 10000L)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1L until 10000L by 2L)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1.0 to 10000.0)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1.0 to 10000.0 by 2.0)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1.0 until 10000.0)).size must be_<(MAX_RANGE_SIZE) // some fixed size
-      serialize((1.0 until 10000.0 by 2.0)).size must be_<(MAX_RANGE_SIZE) // some fixed size
+      serialize((1 to 10000)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1 to 10000 by 2)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1 until 10000)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1 until 10000 by 2)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1L to 10000L)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1L to 10000L by 2L)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1L until 10000L)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1L until 10000L by 2L)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1.0 to 10000.0)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1.0 to 10000.0 by 2.0)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1.0 until 10000.0)).size should be < (MAX_RANGE_SIZE) // some fixed size
+      serialize((1.0 until 10000.0 by 2.0)).size should be < (MAX_RANGE_SIZE) // some fixed size
     }
   }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/config/ReflectingInstantiatorTest.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/config/ReflectingInstantiatorTest.scala
@@ -16,14 +16,14 @@ limitations under the License.
 
 package com.twitter.chill
 
-import org.specs._
+import org.scalatest._
 
 import com.twitter.chill.config._
 
 import org.objenesis.strategy.InstantiatorStrategy;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
-class ReflectingInstantiatorTest extends Specification {
+class ReflectingInstantiatorTest extends WordSpec with Matchers {
   "A ReflectingInstantiator" should {
     "set keys into a config as expected" in {
 
@@ -37,14 +37,14 @@ class ReflectingInstantiatorTest extends Specification {
       val conf = ScalaAnyRefMapConfig.empty
       ri.set(conf)
 
-      conf.toMap(ReflectingInstantiator.KRYO_CLASS) must be_==(classOf[Kryo].getName)
-      conf.toMap(ReflectingInstantiator.INSTANTIATOR_STRATEGY_CLASS) must be_==(classOf[InstantiatorStrategy].getName)
-      conf.toMap(ReflectingInstantiator.REGISTRATION_REQUIRED) must be_==("true")
-      conf.toMap(ReflectingInstantiator.SKIP_MISSING) must be_==("true")
-      conf.toMap(ReflectingInstantiator.REGISTRATIONS).asInstanceOf[String].split(":").toSet must be_== (
+      conf.toMap(ReflectingInstantiator.KRYO_CLASS) should equal(classOf[Kryo].getName)
+      conf.toMap(ReflectingInstantiator.INSTANTIATOR_STRATEGY_CLASS) should equal(classOf[InstantiatorStrategy].getName)
+      conf.toMap(ReflectingInstantiator.REGISTRATION_REQUIRED) should equal("true")
+      conf.toMap(ReflectingInstantiator.SKIP_MISSING) should equal("true")
+      conf.toMap(ReflectingInstantiator.REGISTRATIONS).asInstanceOf[String].split(":").toSet should equal (
         Set("scala.collection.immutable.List",
           "scala.collection.immutable.List,com.esotericsoftware.kryo.serializers.JavaSerializer"))
-      conf.toMap(ReflectingInstantiator.DEFAULT_REGISTRATIONS).asInstanceOf[String].split(":").toSet must be_== (
+      conf.toMap(ReflectingInstantiator.DEFAULT_REGISTRATIONS).asInstanceOf[String].split(":").toSet should equal (
         Set("scala.collection.immutable.List,com.esotericsoftware.kryo.serializers.JavaSerializer"))
     }
     "roundtrip through a config" in {
@@ -58,8 +58,8 @@ class ReflectingInstantiatorTest extends Specification {
       val conf = ScalaAnyRefMapConfig.empty
       ri.set(conf)
       val ri2 = new ReflectingInstantiator(conf)
-      ri.equals(ri2) must be_==(true)
-      ri2.equals(ri) must be_==(true)
+      ri.equals(ri2) should equal(true)
+      ri2.equals(ri) should equal(true)
     }
 
     "be serialized when added onto a ConfiguredInstantiator" in {
@@ -75,7 +75,7 @@ class ReflectingInstantiatorTest extends Specification {
           classOf[ScalaKryoInstantiator],
           instantiator)
       } catch {
-        case e => fail("Got exception serializing the instantiator\n" + e.printStackTrace)
+        case e: Throwable => fail("Got exception serializing the instantiator\n" + e.printStackTrace)
       }
     }
   }

--- a/sbt
+++ b/sbt
@@ -4,7 +4,7 @@
 # Author: Paul Phillips <paulp@typesafe.com>
 
 # todo - make this dynamic
-declare -r sbt_release_version=0.13.0
+declare -r sbt_release_version=0.13.5
 
 declare sbt_jar sbt_dir sbt_create sbt_launch_dir
 declare scala_version java_home sbt_explicit_version


### PR DESCRIPTION
Twitter is about to move to 2.10. This patch clears the way for a 2.11 crossbuild.

relates to #180 
