### PR TITLE
Enable cross compilation for chill-avro

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -225,8 +225,6 @@ object ChillBuild extends Build {
   ).dependsOn(chillJava)
 
   lazy val chillAvro = module("avro").settings(
-    crossPaths := false,
-    autoScalaLibrary := false,
     libraryDependencies ++= Seq(
       "com.twitter" %% "bijection-avro" % "0.7.0"
     )


### PR DESCRIPTION
chill-avro artifact are not tagged with correct Scala version. This PR fixes that
