### PR TITLE
fix default constructor for kryo serialization

### DIFF
--- a/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerialization.java
+++ b/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerialization.java
@@ -50,7 +50,7 @@ public class KryoSerialization extends Configured implements Serialization<Objec
      * It will first call this, then setConf.
      */
     public KryoSerialization() {
-        this(new Configuration());
+	super();
     }
 
     /**


### PR DESCRIPTION
There is no need for the default constructor to create a new Configuration object, since the setConf method will eventually set it.
Calling the new Configuration causes parsing the hadoop-conf xml, which is not necessary
