### PR TITLE
Optimizations for ConfiguredInstantiator.

### DIFF
--- a/chill-java/src/main/java/com/twitter/chill/config/ConfiguredInstantiator.java
+++ b/chill-java/src/main/java/com/twitter/chill/config/ConfiguredInstantiator.java
@@ -174,7 +174,7 @@ public class ConfiguredInstantiator extends KryoInstantiator {
   /** Java's string split is very expensive due to regexes.
    * Implement our own simple version instead.
    */
-  private String[] fastSplitKey(String key) {
+  public static String[] fastSplitKey(String key) {
     int i = key.indexOf(':');
     if(-1 == i) {
       return new String[]{key};

--- a/chill-java/src/test/scala/com/twitter/chill/config/ConfiguredInstantiatorTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/config/ConfiguredInstantiatorTest.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.chill.config
 
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
 import org.scalatest._
 
 import com.twitter.chill._
@@ -47,6 +49,15 @@ class ReflectingInstantiatorTest extends WordSpec with Matchers {
       val cci3 = new ConfiguredInstantiator(conf)
       cci3.getDelegate.getClass should equal(classOf[TestInstTwo])
       cci3.getDelegate should not equal (cci2.getDelegate)
+    }
+  }
+}
+
+object ConfiguredInstantiatorProperties extends Properties("ConfiguredInstantiator") {
+  property("properly split keys") = forAll { (str: String) =>
+    ConfiguredInstantiator.fastSplitKey(str) match {
+      case null => str.split(":").length > 2
+      case success => success.mkString(":") == str
     }
   }
 }


### PR DESCRIPTION
Found these gems when using -Xprof. Each IFile opened on a mapper creates a new ConfiguredInstantiator. The process of deserializing a KyroInstantiator from base64 data is very expensive. This fix simply caches the last one and if the base64 string matches returns it. Our average map time went from 45 minutes to 30 minutes with this fix. Verified via -Xprof that the offending functions were no longer a significant part of the profile.
