### PR TITLE
Add build instructions to readme and make InjectiveSerializer serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Extensions for the [Kryo serialization library](https://github.com/EsotericSoftw
 serializers and a set of classes to ease configuration of Kryo in systems like Hadoop, Storm,
 Akka, etc.
 
+
+### Buidling Chill
+
+```bash
+./sbt
+> compile # to build chill
+> publishM2 # to publish chill to your local .m2 repo
+> publish-local # publish to local ivy repo.
+```
+
 Chill has a set of subprojects: chill-java, chill-hadoop, chill-storm and chill-scala.  Other than
 chill-scala, all these projects are written in Java so they are easy to use on any JVM platform.
 

--- a/chill-bijection/src/main/scala/com/twitter/chill/InjectiveSerializer.scala
+++ b/chill-bijection/src/main/scala/com/twitter/chill/InjectiveSerializer.scala
@@ -1,5 +1,7 @@
 package com.twitter.chill
 
+import _root_.java.io.Serializable
+
 import com.twitter.bijection.Injection
 
 /**
@@ -17,7 +19,7 @@ object InjectiveSerializer {
     new InjectiveSerializer(injection)
 }
 
-class InjectiveSerializer[T] private (injection: Injection[T, Array[Byte]]) extends KSerializer[T] {
+class InjectiveSerializer[T] private (injection: Injection[T, Array[Byte]]) extends KSerializer[T] with Serializable {
   def write(kser: Kryo, out: Output, obj: T) {
     val bytes = injection(obj)
     out.writeInt(bytes.length, true)


### PR DESCRIPTION
Hi,

Apache Flink recently started using chill and Kryo as a fallback serializer. We really like the work done here.
Since we are sending the serializers around in the cluster, they need to be Serializable. I found that the `InjectiveSerializer` is not Serializable, so I made it implement the interface.

I also added some build instructions to the readme, because it took me some time to research the sbt commands.

Please let me know if you want something in this pull request to be solved differently.