### PR TITLE
Rewrite Java BitSet serializer to make it more efficient

### DIFF
--- a/chill-java/src/main/java/com/twitter/chill/java/BitSetSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/BitSetSerializer.java
@@ -17,6 +17,7 @@ limitations under the License.
 package com.twitter.chill.java;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
@@ -24,32 +25,80 @@ import com.esotericsoftware.kryo.io.Output;
 import com.twitter.chill.IKryoRegistrar;
 import com.twitter.chill.SingleRegistrar;
 
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.BitSet;
 
-public class BitSetSerializer extends Serializer<BitSet> {
+public class BitSetSerializer extends Serializer<BitSet> implements Serializable {
 
     static public IKryoRegistrar registrar() {
       return new SingleRegistrar(BitSet.class, new BitSetSerializer());
     }
 
+    private final static Field wordsField;
+    private final static Constructor<BitSet> bitSetConstructor;
+    private final static Method recalculateWordsInUseMethod;
+
+    static {
+        try {
+            wordsField = BitSet.class.getDeclaredField("words");
+            wordsField.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            throw new KryoException("Error while getting field 'words' of bitSet", e);
+        }
+        try {
+            bitSetConstructor = BitSet.class.getDeclaredConstructor(long[].class);
+            bitSetConstructor.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new KryoException("Unable to get BitSet(long[]) constructor", e);
+        }
+        try {
+            recalculateWordsInUseMethod = BitSet.class.getDeclaredMethod("recalculateWordsInUse");
+            recalculateWordsInUseMethod.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            throw new KryoException("Unable to get BitSet.recalculateWordsInUse() method", e);
+        }
+    }
+
     @Override
     public void write(Kryo kryo, Output output, BitSet bitSet) {
-        int len = bitSet.length();
+        long words[] = null;
+        // its sufficent to get only the 'words' field because
+        // we can recompute the wordsInUse after deserialization
+        try {
+            words = (long[]) wordsField.get(bitSet);
+        } catch (IllegalAccessException e) {
+            throw new KryoException("Error while accessing field 'words' of bitSet", e);
+        }
+        output.writeInt(words.length, true);
 
-        output.writeInt(len, true);
-
-        for(int i = 0; i < len; i++) {
-            output.writeBoolean(bitSet.get(i));
+        for(int i = 0; i < words.length; i++) {
+            output.writeLong(words[i]);
         }
     }
 
     @Override
     public BitSet read(Kryo kryo, Input input, Class<BitSet> bitSetClass) {
         int len = input.readInt(true);
-        BitSet ret = new BitSet(len);
+        long[] target = new long[len];
 
         for(int i = 0; i < len; i++) {
-            ret.set(i, input.readBoolean());
+            target[i] = input.readLong();
+        }
+
+        BitSet ret = null;
+        // call a private constructor: (the BitSet.valueOf() cTor is only available from Java 1.7)
+        try {
+            ret = bitSetConstructor.newInstance(target);
+        } catch (ReflectiveOperationException e) {
+            throw new KryoException("Unable to call BitSet(long[]) constructor", e);
+        }
+        try {
+            recalculateWordsInUseMethod.invoke(ret);
+        } catch (ReflectiveOperationException e) {
+            throw new KryoException("Unable to call BitSet.recalculateWordsInUse() method", e);
         }
 
         return ret;

--- a/chill-java/src/test/scala/com/twitter/chill/java/BitSetTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/BitSetTest.scala
@@ -1,0 +1,91 @@
+package com.twitter.chill.java
+
+import java.util
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.{Input, Output}
+import org.objenesis.strategy.StdInstantiatorStrategy
+import org.scalatest._
+
+import scala.util.Random
+
+class BitSetSpec extends WordSpec with MustMatchers {
+
+  implicit val kryo = new Kryo()
+
+  def rt[A](a: A)(implicit k: Kryo): A = {
+    val out = new Output(1000, -1)
+    k.writeClassAndObject(out, a.asInstanceOf[AnyRef])
+    val in = new Input(out.toBytes)
+    k.readClassAndObject(in).asInstanceOf[A]
+  }
+
+  "A BitSetSerializer serializer" should {
+    "handle BitSet" in {
+      kryo.setInstantiatorStrategy(new StdInstantiatorStrategy)
+      BitSetSerializer.registrar()(kryo)
+      var simple = new util.BitSet(2048)
+      simple.size() must be(2048)
+      for (i <- 0 to 1337) {
+        simple.set(i, true)
+      }
+      // we assume everything after 1337 to be false
+      simple.get(1338) must equal(false)
+      simple.get(2000) must equal(false)
+      var dolly = rt(simple)
+      simple = null // avoid accidental calls
+      dolly.size() must be(2048)
+      for (i <- 0 to 1337) {
+        dolly.get(i) must be(true)
+      }
+      dolly.get(1338) must equal(false)
+      dolly.get(2000) must equal(false)
+    }
+
+    /**
+     * My results:
+     * The old serializer took 2886ms
+     * The new serializer took 112ms
+     * The old serializer needs 2051 bytes
+     * The new serializer needs 258 bytes
+     */
+    "handle a BitSet efficiently" in {
+      val oldKryo = new Kryo()
+      OldBitSetSerializer.registrar()(oldKryo)
+
+      val newKryo = new Kryo()
+      BitSetSerializer.registrar()(newKryo)
+
+      val element = new util.BitSet(2048)
+      val rnd = new Random()
+      for (i <- 0 to 2048) {
+        element.set(i, rnd.nextBoolean())
+      }
+
+      // warmup In case anybody wants to see hotspot
+      for(i <- 0 to 50000) {
+        rt(element)(oldKryo)
+      }
+      var start = System.currentTimeMillis()
+      for(i <- 0 to 100000) {
+        rt(element)(oldKryo)
+      }
+      println("The old serializer took "+(System.currentTimeMillis() - start)+"ms")
+
+      start = System.currentTimeMillis()
+      for(i <- 0 to 100000) {
+        rt(element)(newKryo)
+      }
+      println("The new serializer took "+(System.currentTimeMillis() - start)+"ms")
+
+      var out = new Output(1, -1)
+      oldKryo.writeObject(out, element)
+      out.flush()
+      println("The old serializer needs "+out.total()+" bytes")
+      out = new Output(1, -1)
+      newKryo.writeObject(out, element)
+      out.flush()
+      println("The new serializer needs "+out.total()+" bytes")
+    }
+  }
+}

--- a/chill-java/src/test/scala/com/twitter/chill/java/LocaleTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/LocaleTest.scala
@@ -18,9 +18,9 @@ package com.twitter.chill.java
 
 import org.scalatest._
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
 
 import org.objenesis.strategy.StdInstantiatorStrategy
 

--- a/chill-java/src/test/scala/com/twitter/chill/java/OldBitSetSerializer.java
+++ b/chill-java/src/test/scala/com/twitter/chill/java/OldBitSetSerializer.java
@@ -1,0 +1,56 @@
+/*
+Copyright 2013 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.twitter.chill.IKryoRegistrar;
+import com.twitter.chill.SingleRegistrar;
+
+import java.util.BitSet;
+
+public class OldBitSetSerializer extends Serializer<BitSet> {
+
+    static public IKryoRegistrar registrar() {
+      return new SingleRegistrar(BitSet.class, new OldBitSetSerializer());
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, BitSet bitSet) {
+        int len = bitSet.length();
+
+        output.writeInt(len, true);
+
+        for(int i = 0; i < len; i++) {
+            output.writeBoolean(bitSet.get(i));
+        }
+    }
+
+    @Override
+    public BitSet read(Kryo kryo, Input input, Class<BitSet> bitSetClass) {
+        int len = input.readInt(true);
+        BitSet ret = new BitSet(len);
+
+        for(int i = 0; i < len; i++) {
+            ret.set(i, input.readBoolean());
+        }
+
+        return ret;
+    }
+}

--- a/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
@@ -18,9 +18,9 @@ package com.twitter.chill.java
 
 import org.scalatest._
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
 
 import org.objenesis.strategy.StdInstantiatorStrategy
 


### PR DESCRIPTION
The new serializer is not writing an entire byte per bit.
To access the internal state of BitSet, I have to use Java reflection. The Java 1.7 implementation of BitSet allows to access the internal long[], but chill is compatible to Java 1.6, so we have to play some tricks here.

My experiments show that the new code is 4 times more space efficient (514 vs 2052 bytes) and 11 times faster (446 vs 4908 ms) [both in 100000 ser-deser rounds]