### PR TITLE
Alter scala collection default serializer registration order

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -123,6 +123,8 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forTraversableSubclass(Queue.empty[Any])
       // List is a sealed class, so there are only two subclasses:
       .forTraversableSubclass(List.empty[Any])
+      // Add ListBuffer subclass before Buffer to prevent the more general case taking precedence
+      .forTraversableSubclass(ListBuffer.empty[Any], isImmutable = false)
       // add mutable Buffer before Vector, otherwise Vector is used
       .forTraversableSubclass(Buffer.empty[Any], isImmutable = false)
       // Vector is a final class
@@ -159,7 +161,6 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forTraversableSubclass(MQueue.empty[Any], isImmutable = false)
       .forTraversableSubclass(MMap.empty[Any, Any], isImmutable = false)
       .forTraversableSubclass(MSet.empty[Any], isImmutable = false)
-      .forTraversableSubclass(ListBuffer.empty[Any], isImmutable = false)
   }
 }
 


### PR DESCRIPTION
In the event that a class is not registered and Kryo falls back on implicit registration it will check the registered default serializers in the order they were registered until it finds one that could apply. Currently in ScalaKryoInstantiator the more general Buffer appears before ListBuffer, so when serializing/deserializing a ListBuffer in this situation, the Buffer serializer will be chosen, and you will end up with an ArrayBuffer on the receiving end, potentially occupying a variable the JVM is convinced is a ListBuffer, which leads to serious problems. This change simply ensures that ListBuffer is registered first.