### PR TITLE
Version Upgrade & Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 sudo: false
 scala:
-  - 2.10.4
-  - 2.11.2
+  - 2.11.7
+jdk:
+   - oraclejdk8
+

--- a/NOTICE
+++ b/NOTICE
@@ -3,9 +3,9 @@ Copyright 2012 Twitter, Inc.
 
 Third Party Dependencies:
 
-Kryo 2.17
+Kryo 3.0.2
 BSD 3-Clause License
-http://code.google.com/p/kryo
+https://github.com/EsotericSoftware/kryo
 
 Commons-Codec 1.7
 Apache Public License 2.0

--- a/chill-akka/src/main/scala/com/twitter/chill/akka/ActorRefSerializer.scala
+++ b/chill-akka/src/main/scala/com/twitter/chill/akka/ActorRefSerializer.scala
@@ -17,8 +17,7 @@ package com.twitter.chill.akka
  * ****************************************************************************
  */
 
-import akka.actor.ExtendedActorSystem
-import akka.actor.ActorRef
+import akka.actor.{ ActorSelection, ExtendedActorSystem, ActorRef }
 import akka.serialization.Serialization
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer

--- a/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerializer.java
+++ b/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerializer.java
@@ -47,7 +47,7 @@ public class KryoSerializer implements Serializer<Object> {
         try {
           st.writeObject(o);
           // Copy from buffer to output stream.
-          outputStream.writeInt(st.numOfWrittenBytes());
+          outputStream.writeInt((int)st.numOfWrittenBytes());
           st.writeOutputTo(outputStream);
         }
         finally {

--- a/chill-hadoop/src/test/scala/com/twitter/chill/hadoop/HadoopTests.scala
+++ b/chill-hadoop/src/test/scala/com/twitter/chill/hadoop/HadoopTests.scala
@@ -18,17 +18,15 @@ package com.twitter.chill.hadoop
 
 import org.scalatest._
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.Kryo
 
 import org.objenesis.strategy.StdInstantiatorStrategy
 
 import java.io.{ ByteArrayOutputStream => BAOut, ByteArrayInputStream => BAIn }
-import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configuration
 
-import com.twitter.chill.config.ConfiguredInstantiator;
-import com.twitter.chill.KryoInstantiator;
+import com.twitter.chill.config.ConfiguredInstantiator
+import com.twitter.chill.KryoInstantiator
 
 class StdKryoInstantiator extends KryoInstantiator {
   override def newKryo = {
@@ -44,13 +42,13 @@ class HadoopTests extends WordSpec with Matchers {
     val ks = k.getSerializer(cls)
     ks.open(out)
     ks.serialize(a)
-    ks.close
+    ks.close()
 
     val in = new BAIn(out.toByteArray)
     val kd = k.getDeserializer(cls)
     kd.open(in)
     val res = kd.deserialize(null)
-    kd.close
+    kd.close()
     res.asInstanceOf[A]
   }
 

--- a/chill-java/src/main/java/com/twitter/chill/Base64.java
+++ b/chill-java/src/main/java/com/twitter/chill/Base64.java
@@ -6,7 +6,7 @@ package com.twitter.chill;
  * <p>Example:</p>
  *
  * <code>String encoded = Base64.encode( myByteArray );</code>
- * <br />
+ * <br>
  * <code>byte[] myByteArray = Base64.decode( encoded );</code>
  *
  * <p>The <tt>options</tt> parameter, which appears in a few places, is used to pass
@@ -1112,6 +1112,7 @@ public class Base64
      *
      * @param source The Base64 encoded data
      * @return decoded data
+     * @throws java.io.IOException if an IO error occurs
      * @since 2.3.1
      */
     public static byte[] decode( byte[] source )
@@ -1668,7 +1669,7 @@ public class Base64
          * Valid options:<pre>
          *   ENCODE or DECODE: Encode or Decode as data is read.
          *   DO_BREAK_LINES: break lines at 76 characters
-         *     (only meaningful when encoding)</i>
+         *     <i>(only meaningful when encoding)</i>
          * </pre>
          * <p>
          * Example: <code>new Base64.InputStream( in, Base64.DECODE )</code>
@@ -1881,7 +1882,7 @@ public class Base64
          * Valid options:<pre>
          *   ENCODE or DECODE: Encode or Decode as data is read.
          *   DO_BREAK_LINES: don't break lines at 76 characters
-         *     (only meaningful when encoding)</i>
+         *     <i>(only meaningful when encoding)</i>
          * </pre>
          * <p>
          * Example: <code>new Base64.OutputStream( out, Base64.ENCODE )</code>

--- a/chill-java/src/main/java/com/twitter/chill/KryoPool.java
+++ b/chill-java/src/main/java/com/twitter/chill/KryoPool.java
@@ -36,7 +36,14 @@ abstract public class KryoPool extends ResourcePool<SerDeState> {
     st.clear();
     super.release(st);
   }
-  /** Output is created with new Output(outBufferMin, outBufferMax);
+
+  /** Output is created with new Output(outBufferMin, outBufferMax)
+   *
+   * @param poolSize The maximum size of the pool
+   * @param ki The KryoInstantiator to use for new instances of Kryo
+   * @param outBufferMin The minimum size of the output buffer
+   * @param outBufferMax The maximum size of the output buffer
+   * @return A KryoPool with the requested parameters
    */
   public static KryoPool withBuffer(int poolSize,
       final KryoInstantiator ki,
@@ -49,8 +56,11 @@ abstract public class KryoPool extends ResourcePool<SerDeState> {
     };
   }
 
-  /** Output is created with new Output(new ByteArrayOutputStream())
+  /** Output is created with new Output(new ByteArrayOutputStream()
    * This will automatically resize internally
+   * @param poolSize The size of the pool to create
+   * @param ki The KryoInstantiator to use for new Kryo Instances
+   * @return A KryoPool that automatically resizes internally
    */
   public static KryoPool withByteArrayOutputStream(int poolSize,
       final KryoInstantiator ki) {
@@ -84,7 +94,7 @@ abstract public class KryoPool extends ResourcePool<SerDeState> {
   }
 
   public <T> T deepCopy(T obj) {
-    return (T)fromBytes(toBytesWithoutClass(obj), obj.getClass());
+    return (T)fromBytes(toBytesWithoutClass(obj), obj.getClass()) ;
   }
 
   public Object fromBytes(byte[] ary) {

--- a/chill-java/src/main/java/com/twitter/chill/ReflectingDefaultRegistrar.java
+++ b/chill-java/src/main/java/com/twitter/chill/ReflectingDefaultRegistrar.java
@@ -32,7 +32,9 @@ public class ReflectingDefaultRegistrar<T> implements IKryoRegistrar {
   public Class<T> getRegisteredClass() { return klass; }
   public Class<? extends Serializer<?>> getSerializerClass() { return serializerKlass; }
   @Override
-  public void apply(Kryo k) { k.addDefaultSerializer(klass, k.newSerializer(serializerKlass, klass)); }
+  public void apply(Kryo k) {
+    k.addDefaultSerializer(klass, serializerKlass);
+  }
 
   @Override
   public int hashCode() { return klass.hashCode() ^ serializerKlass.hashCode(); }

--- a/chill-java/src/main/java/com/twitter/chill/ReflectingRegistrar.java
+++ b/chill-java/src/main/java/com/twitter/chill/ReflectingRegistrar.java
@@ -35,7 +35,10 @@ public class ReflectingRegistrar<T> implements IKryoRegistrar {
     serializerKlass = ser;
   }
   @Override
-  public void apply(Kryo k) { k.register(klass, k.newSerializer(serializerKlass, klass)); }
+  public void apply(Kryo k) {
+    k.register(klass, k.getDefaultSerializer(serializerKlass));
+  }
+
   @Override
   public int hashCode() { return klass.hashCode() ^ serializerKlass.hashCode(); }
 

--- a/chill-java/src/main/java/com/twitter/chill/SerDeState.java
+++ b/chill-java/src/main/java/com/twitter/chill/SerDeState.java
@@ -50,8 +50,8 @@ public class SerDeState {
   public void setInput(byte[] in, int offset, int count) { input.setBuffer(in, offset, count); }
   public void setInput(InputStream in) { input.setInputStream(in); }
 
-  public int numOfWrittenBytes() { return output.total(); }
-  public int numOfReadBytes() { return input.total(); }
+  public long numOfWrittenBytes() { return output.total(); }
+  public long numOfReadBytes() { return input.total(); }
 
   // Common operations:
   public <T> T readObject(Class<T> cls) {

--- a/chill-java/src/main/java/com/twitter/chill/config/Config.java
+++ b/chill-java/src/main/java/com/twitter/chill/config/Config.java
@@ -20,7 +20,11 @@ package com.twitter.chill.config;
  *
  */
 abstract public class Config {
-  /** Return null if this key is undefined */
+  /** Return null if this key is undefined
+   *
+   * @param key The key of the value to extract from the configuration
+   * @return The configured value
+   */
   abstract public String get(String key);
   abstract public void set(String key, String value);
 

--- a/chill-java/src/main/java/com/twitter/chill/config/ConfiguredInstantiator.java
+++ b/chill-java/src/main/java/com/twitter/chill/config/ConfiguredInstantiator.java
@@ -40,7 +40,7 @@ public class ConfiguredInstantiator extends KryoInstantiator {
   protected final KryoInstantiator delegate;
 
   /** Key we use to configure this class.
-   * Format: <class of KryoInstantiator>(:<base64 serialized instantiator>)
+   * Format: {@code <class of KryoInstantiator>(:< base64 serialized instantiator\>) }
    * if there is no serialized instantiator, we use the reflected instance
    * as the delegate
    */
@@ -77,7 +77,10 @@ public class ConfiguredInstantiator extends KryoInstantiator {
   /** Calls through to the delegate */
   public Kryo newKryo() { return delegate.newKryo(); }
 
-  /** Return the delegated KryoInstantiator */
+  /** Return the delegated KryoInstantiator
+   *
+   * @return The delegated KryoInstantiator
+   */
   public KryoInstantiator getDelegate() {
     return delegate;
   }
@@ -85,6 +88,8 @@ public class ConfiguredInstantiator extends KryoInstantiator {
   /** In this mode, we are just refecting to another delegated class. This is preferred
    * if you don't have any configuration to do at runtime (i.e. you can make a named class
    * that has all the logic for your KryoInstantiator).
+   * @param conf The configuration
+   * @param instClass The class of the KryoInstantiator to use
    */
   public static void setReflect(Config conf, Class<? extends KryoInstantiator> instClass) {
     conf.set(KEY, instClass.getName());
@@ -116,6 +121,9 @@ public class ConfiguredInstantiator extends KryoInstantiator {
 
   /** Use the default KryoInstantiator to serialize the KryoInstantiator ki
    * same as: setSerialized(conf, KryoInstantiator.class, ki)
+   * @param conf The Config to use
+   * @param ki The KryoInstantiator
+   * @throws ConfigurationException
    */
   public static void setSerialized(Config conf, KryoInstantiator ki)
     throws ConfigurationException {
@@ -125,6 +133,10 @@ public class ConfiguredInstantiator extends KryoInstantiator {
   /** If this reflector needs config to be set, that should be done PRIOR to making this call.
    * This mode serializes an instance (ki) to be used as the delegate.
    * Only use this mode if reflection alone will not work.
+   * @param conf The Config to use
+   * @param reflector The class of the KryoInstantiator
+   * @param ki The KryoInstantiator
+   * @throws ConfigurationException
    */
   public static void setSerialized(Config conf, Class<? extends KryoInstantiator> reflector, KryoInstantiator ki)
     throws ConfigurationException {

--- a/chill-java/src/test/scala/com/twitter/chill/java/BitSetTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/BitSetTest.scala
@@ -3,7 +3,7 @@ package com.twitter.chill.java
 import java.util
 
 import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.io.{ Input, Output }
 import org.objenesis.strategy.StdInstantiatorStrategy
 import org.scalatest._
 
@@ -63,19 +63,19 @@ class BitSetSpec extends WordSpec with MustMatchers {
       }
 
       // warmup In case anybody wants to see hotspot
-      var lastBitSetFromOld : util.BitSet = null
-      for(i <- 0 to 50000) {
+      var lastBitSetFromOld: util.BitSet = null
+      for (i <- 0 to 50000) {
         lastBitSetFromOld = rt(element)(oldKryo)
       }
       var start = System.currentTimeMillis()
-      for(i <- 0 to 100000) {
+      for (i <- 0 to 100000) {
         rt(element)(oldKryo)
       }
-      println("The old serializer took "+(System.currentTimeMillis() - start)+"ms")
+      println("The old serializer took " + (System.currentTimeMillis() - start) + "ms")
 
-      var lastBitSetFromNew : util.BitSet = null
+      var lastBitSetFromNew: util.BitSet = null
       // warmup for the new kryo
-      for(i <- 0 to 50000) {
+      for (i <- 0 to 50000) {
         lastBitSetFromNew = rt(element)(newKryo)
       }
       // check for the three bitsets to be equal
@@ -87,23 +87,22 @@ class BitSetSpec extends WordSpec with MustMatchers {
         element.get(i) must be(lastBitSetFromNew.get(i))
       }
 
-
       start = System.currentTimeMillis()
-      for(i <- 0 to 100000) {
+      for (i <- 0 to 100000) {
         rt(element)(newKryo)
       }
-      println("The new serializer took "+(System.currentTimeMillis() - start)+"ms")
+      println("The new serializer took " + (System.currentTimeMillis() - start) + "ms")
 
       var out = new Output(1, -1)
       oldKryo.writeObject(out, element)
       out.flush()
       var oldBytes = out.total()
-      println("The old serializer needs "+oldBytes+" bytes")
+      println("The old serializer needs " + oldBytes + " bytes")
       out = new Output(1, -1)
       newKryo.writeObject(out, element)
       out.flush()
       var newBytes = out.total()
-      println("The new serializer needs "+newBytes+" bytes")
+      println("The new serializer needs " + newBytes + " bytes")
 
       oldBytes >= newBytes must be(true)
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,12 +20,10 @@ object ChillBuild extends Build {
 
     version := "0.7.0-SNAPSHOT",
     organization := "com.twitter",
-    scalaVersion := "2.10.5",
-    crossScalaVersions := Seq("2.10.5", "2.11.7"),
+    scalaVersion := "2.11.7",
     scalacOptions ++= Seq("-unchecked", "-deprecation"),
     ScalariformKeys.preferences := formattingPreferences,
 
-    // Twitter Hadoop needs this, sorry 1.7 fans
     javacOptions ++= Seq("-Xlint:-options", "-Xlint:unchecked"),
     javacOptions in doc := Seq(),
 
@@ -34,8 +32,8 @@ object ChillBuild extends Build {
       Opts.resolver.sonatypeReleases
     ),
     libraryDependencies ++= Seq(
-      "org.scalacheck" %% "scalacheck" % "1.11.5" % "test",
-      "org.scalatest" %% "scalatest" % "2.2.2" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.12.4" % "test",
+      "org.scalatest" %% "scalatest" % "2.2.5" % "test",
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion
     ),
 
@@ -183,8 +181,8 @@ object ChillBuild extends Build {
     autoScalaLibrary := false,
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-core" % "0.20.2" % "provided",
-      "org.slf4j" % "slf4j-api" % "1.6.6",
-      "org.slf4j" % "slf4j-log4j12" % "1.6.6" % "provided"
+      "org.slf4j" % "slf4j-api" % "1.7.12",
+      "org.slf4j" % "slf4j-log4j12" % "1.7.12" % "provided"
     )
   ).dependsOn(chillJava)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,13 +4,11 @@ import sbt._
 import Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import com.typesafe.tools.mima.plugin.MimaKeys._
-import scalariform.formatter.preferences._
 import com.typesafe.sbt.SbtScalariform._
 
-import scala.collection.JavaConverters._
 
 object ChillBuild extends Build {
-  val kryoVersion = "2.21"
+  val kryoVersion = "3.0.2"
 
 
   def isScala210x(scalaVersion: String) = scalaVersion match {
@@ -18,18 +16,18 @@ object ChillBuild extends Build {
       case _ => false
   }
 
-  val sharedSettings = Project.defaultSettings ++ mimaDefaultSettings ++ scalariformSettings ++ Seq(
+  val sharedSettings = Defaults.coreDefaultSettings ++ mimaDefaultSettings ++ scalariformSettings ++ Seq(
 
-    version := "0.6.0",
+    version := "0.7.0-SNAPSHOT",
     organization := "com.twitter",
     scalaVersion := "2.10.5",
-    crossScalaVersions := Seq("2.10.5", "2.11.5"),
+    crossScalaVersions := Seq("2.10.5", "2.11.7"),
     scalacOptions ++= Seq("-unchecked", "-deprecation"),
     ScalariformKeys.preferences := formattingPreferences,
 
     // Twitter Hadoop needs this, sorry 1.7 fans
-    javacOptions ++= Seq("-target", "1.6", "-source", "1.6", "-Xlint:-options"),
-    javacOptions in doc := Seq("-source", "1.6"),
+    javacOptions ++= Seq("-Xlint:-options", "-Xlint:unchecked"),
+    javacOptions in doc := Seq(),
 
     resolvers ++= Seq(
       Opts.resolver.sonatypeSnapshots,
@@ -38,7 +36,7 @@ object ChillBuild extends Build {
     libraryDependencies ++= Seq(
       "org.scalacheck" %% "scalacheck" % "1.11.5" % "test",
       "org.scalatest" %% "scalatest" % "2.2.2" % "test",
-      "com.esotericsoftware.kryo" % "kryo" % kryoVersion
+      "com.esotericsoftware" % "kryo-shaded" % kryoVersion
     ),
 
     parallelExecution in Test := true,
@@ -123,7 +121,7 @@ object ChillBuild extends Build {
 
   def youngestForwardCompatible(subProj: String) =
     Some(subProj)
-      .filterNot(unreleasedModules.contains(_))
+      .filterNot(unreleasedModules.contains)
       .map { s =>
       val suffix = if (javaOnly.contains(s)) "" else "_2.10"
       "com.twitter" % ("chill-" + s + suffix) % "0.6.0"
@@ -145,20 +143,20 @@ object ChillBuild extends Build {
     settings = sharedSettings
   ).settings(
     name := "chill",
-    previousArtifact := Some("com.twitter" % "chill_2.10" % "0.5.0")
+    previousArtifact := Some("com.twitter" % "chill_2.10" % "0.6.0")
   ).dependsOn(chillJava)
 
   lazy val chillAkka = module("akka").settings(
     resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
     libraryDependencies ++= Seq(
-      "com.typesafe" % "config" % "1.2.1",
-      "com.typesafe.akka" %% "akka-actor" % "2.3.6" % "provided"
+      "com.typesafe" % "config" % "1.3.0",
+      "com.typesafe.akka" %% "akka-actor" % "2.3.11" % "provided"
     )
   ).dependsOn(chill % "test->test;compile->compile")
 
   lazy val chillBijection = module("bijection").settings(
     libraryDependencies ++= Seq(
-      "com.twitter" %% "bijection-core" % "0.8.0"
+      "com.twitter" %% "bijection-core" % "0.8.1"
     )
   ).dependsOn(chill % "test->test;compile->compile")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,8 @@
-resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+// resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+
+scalacOptions := Seq("-deprecation")
+
+scalaVersion := "2.10.5"
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 


### PR DESCRIPTION
- Chill: 0.6.0 -> 0.7.0-SNAPSHOT
- SBT: 0.13.5 -> 0.13.8
- Kryo: 2.21 -> 3.0.2
- Scala: 2.11.5 -> 2.11.7
- Akka-Core: 2.3.6 -> 2.3.11
- Bijection-Core: 0.8.0 -> 0.8.1
- Typesafe Config: 1.2.1 -> 1.3.0
- Java: Remove restriction on 1.6 target bytecode (might break Hadoop?)
- Change the organization name for the kryo package for the change in the 3.0 release.
- Use the kryo-shaded library
- Add -Xlint:unchecked to identify numerous unchecked warnings
- Avoid some long->int truncations
- Deal with ObjectInstantiator now having type arguments
- Clean up JavaDoc so it doesn't fail

FYI: For me this passes all tests and publishes locally.
