### PR TITLE
SketchMap Serializer

### DIFF
--- a/chill-algebird/src/main/scala/com/twitter/chill/algebird/AlgebirdSerializers.scala
+++ b/chill-algebird/src/main/scala/com/twitter/chill/algebird/AlgebirdSerializers.scala
@@ -19,20 +19,11 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.{ Serializer => KSerializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
 
-import com.twitter.algebird.{
-  AveragedValue,
-  DecayedValue,
-  HLL,
-  HyperLogLog,
-  HyperLogLogMonoid,
-  Moments,
-  SpaceSaver,
-  SSOne,
-  SSMany
-}
+import com.twitter.algebird._
+import com.twitter.algebird.matrix.AdaptiveMatrix
 
 import scala.collection.mutable.{ Map => MMap }
-import scala.collection.immutable.SortedMap
+
 
 class AveragedValueSerializer extends KSerializer[AveragedValue] {
   setImmutable(true)
@@ -94,4 +85,43 @@ class HLLMonoidSerializer extends KSerializer[HyperLogLogMonoid] {
     val bits = in.readInt(true)
     hllMonoids.getOrElseUpdate(bits, new HyperLogLogMonoid(bits))
   }
+}
+
+class SketchMapSerializer[K, V](implicit skmMonoid: SketchMapMonoid[K, V], valueMonoid: Monoid[V])
+  extends KSerializer[SketchMap[K, V]] {
+
+  def write(kryo: Kryo, output: Output, skm: SketchMap[K, V]) {
+    val rows = skm.valuesTable.rows
+    val cols = skm.valuesTable.cols
+
+    val values: IndexedSeq[(Int, Int, V)] =
+      for (
+        r: Int <- 0 to rows - 1; c: Int <- 0 to cols - 1 if skm.valuesTable.getValue((r, c)) != valueMonoid.zero
+      ) yield (r, c, skm.valuesTable.getValue((r, c)))
+
+    output.writeInt(rows, true)
+    output.writeInt(cols, true)
+    kryo.writeClassAndObject(output, values.toList)
+    kryo.writeClassAndObject(output, skm.totalValue)
+    kryo.writeClassAndObject(output, skm.heavyHitterKeys)
+
+    output.flush()
+  }
+
+  def read(kryo: Kryo, in: Input, cls: Class[SketchMap[K, V]]): SketchMap[K, V] = {
+    val rowsOrig = in.readInt(true)
+    val colsOrig = in.readInt(true)
+    val values = kryo.readClassAndObject(in).asInstanceOf[List[(Int, Int, V)]]
+    val totalValue = kryo.readClassAndObject(in).asInstanceOf[V]
+    val heavyHitterKeys = kryo.readClassAndObject(in).asInstanceOf[List[K]]
+
+    val rows = if (rowsOrig == 0) skmMonoid.params.depth else rowsOrig
+    val cols = if (colsOrig == 0) skmMonoid.params.width else colsOrig
+
+    val zero = AdaptiveMatrix.fill[V](rows, cols)(valueMonoid.zero)
+    val valuesTable = values.foldLeft(zero){ case (acc, (r, c, v)) ⇒ acc.updated((r, c), v) }
+
+    SketchMap(valuesTable, heavyHitterKeys, totalValue)
+  }
+
 }


### PR DESCRIPTION
Hello, 
In our system we store the SketchMap as a blob in Postgres, to do so we need somehow serialize it into binary, initially we used the standard Kryo serializer - FieldSerializer. It worked, but after we tried to upgrade our dependence on algebird from 0.4 to 0.6 the deserialization failed. The internal implementation of SketchMap changed and  FieldSerializer was not able to map stored binaries back to new SketchMap. We needed to come up with a serialization that would survive betweens the upgrades. 

Proposed is SketchMap Serializer that depends on public Algebird API, generic to types of key and values and has a small footprint (it tries to serialize only the non zero value bits).

Thank you for your consideration. 

P.S. The proposed serializer is currently used in our production system.
