### PR TITLE
Publish artifacts for javaOnly when scalaVersion is 2.10.x

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -136,7 +136,7 @@ object ChillBuild extends Build {
       previousArtifact := youngestForwardCompatible(name),
       // Disable cross publishing for java artifacts
       publishArtifact <<= (scalaVersion) { scalaVersion =>
-        if(javaOnly.contains(name) && scalaVersion.startsWith("2.10")) false else true
+        if(javaOnly.contains(name) && scalaVersion.startsWith("2.11")) false else true
       }
       )
     )


### PR DESCRIPTION
We are currently checking if the scalaVersion is 2.10.x, and not publishing javaOnly artifacts if that is the case - to avoid publishing the jars twice. I am flipping the check to test whether the scalaVersion is 2.11.x and not publishing in that case. 

*Why*? There doesn't seem to be an easy way to set the scala version using dbuild (https://github.com/sriramkrishnan/twitter-oss-dbuild). So dbuild uses the scalaVersion in the Build.scala, which is 2.10.5 - and hence doesn't publish the javaOnly projects, and hence failing the downstream projects that depend on it.

This should essentially be a no-op for chill - the javaOnly projects should still be published once, but this time when the scalaVersion is the default, i.e. 2.10.5.

CC @ianoc @isnotinvain 