### PR TITLE
Upgrade to kryo-2.22

### DIFF
--- a/chill-avro/src/test/java/com/twitter/chill/avro/AvroSerializerJavaTest.java
+++ b/chill-avro/src/test/java/com/twitter/chill/avro/AvroSerializerJavaTest.java
@@ -11,7 +11,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.junit.Before;
 import org.junit.Test;
-import org.objenesis.strategy.StdInstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
 import scala.reflect.ClassTag;
 
 import static org.junit.Assert.assertEquals;

--- a/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerialization.java
+++ b/chill-hadoop/src/main/java/com/twitter/chill/hadoop/KryoSerialization.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.serializer.Deserializer;
 import org.apache.hadoop.io.serializer.Serialization;
 import org.apache.hadoop.io.serializer.Serializer;
-import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import com.twitter.chill.KryoPool;
 import com.twitter.chill.KryoInstantiator;

--- a/chill-hadoop/src/test/scala/com/twitter/chill/hadoop/HadoopTests.scala
+++ b/chill-hadoop/src/test/scala/com/twitter/chill/hadoop/HadoopTests.scala
@@ -22,7 +22,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
-import org.objenesis.strategy.StdInstantiatorStrategy
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy
 
 import java.io.{ ByteArrayOutputStream => BAOut, ByteArrayInputStream => BAIn }
 import org.apache.hadoop.conf.Configuration;

--- a/chill-java/src/main/java/com/twitter/chill/KryoInstantiator.java
+++ b/chill-java/src/main/java/com/twitter/chill/KryoInstantiator.java
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.chill;
 
 import com.esotericsoftware.kryo.Kryo;
-import org.objenesis.strategy.InstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.InstantiatorStrategy;
 import java.io.Serializable;
 
 /** Class to create a new Kryo instance.

--- a/chill-java/src/main/java/com/twitter/chill/config/ReflectingInstantiator.java
+++ b/chill-java/src/main/java/com/twitter/chill/config/ReflectingInstantiator.java
@@ -24,8 +24,8 @@ import com.twitter.chill.ReflectingDefaultRegistrar;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
-import org.objenesis.strategy.InstantiatorStrategy;
-import org.objenesis.strategy.StdInstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.InstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
 import java.util.ArrayList;
 import java.util.List;
 import java.lang.reflect.InvocationTargetException;
@@ -138,9 +138,13 @@ public class ReflectingInstantiator extends KryoInstantiator {
   public static final String KRYO_CLASS_DEFAULT = Kryo.class.getName();
   /**
    * Name of the InstatiatorStrategy to use.
-   * If this is empty, we use org.objenesis.strategy.StdInstantiatorStrategy
+   * If this is empty, we use the value in {@link @INSTANTIATOR_STRATEGY_CLASS_DEFAULT}
    */
   public static final String INSTANTIATOR_STRATEGY_CLASS = prefix + ".instantiatorstrategyclass";
+
+  /**
+   * Default strategy: {@value}
+   */
   public static final String INSTANTIATOR_STRATEGY_CLASS_DEFAULT = StdInstantiatorStrategy.class.getName();
   /**
    * KRYO_REGISTRATIONS holds a colon-separated list of classes to register with Kryo.

--- a/chill-java/src/test/scala/com/twitter/chill/java/BitSetTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/BitSetTest.scala
@@ -4,7 +4,7 @@ import java.util
 
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.{ Input, Output }
-import org.objenesis.strategy.StdInstantiatorStrategy
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy
 import org.scalatest._
 
 import scala.util.Random

--- a/chill-java/src/test/scala/com/twitter/chill/java/LocaleTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/LocaleTest.scala
@@ -22,7 +22,7 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 
-import org.objenesis.strategy.StdInstantiatorStrategy
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy
 
 import _root_.java.util.Locale
 

--- a/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/PriorityQueueTest.scala
@@ -22,7 +22,7 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 
-import org.objenesis.strategy.StdInstantiatorStrategy
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy
 
 class PriorityQueueSpec extends WordSpec with Matchers {
 

--- a/chill-scala/src/main/scala/com/twitter/chill/KryoBase.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/KryoBase.scala
@@ -20,8 +20,8 @@ import com.esotericsoftware.kryo.KryoException
 import com.esotericsoftware.reflectasm.ConstructorAccess
 import com.esotericsoftware.kryo.serializers.FieldSerializer
 
-import org.objenesis.instantiator.ObjectInstantiator
-import org.objenesis.strategy.InstantiatorStrategy
+import com.esotericsoftware.shaded.org.objenesis.instantiator.ObjectInstantiator
+import com.esotericsoftware.shaded.org.objenesis.strategy.InstantiatorStrategy
 
 import _root_.java.lang.reflect.{ Constructor, Modifier }
 

--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -56,7 +56,7 @@ class EmptyScalaKryoInstantiator extends KryoInstantiator {
   override def newKryo = {
     val k = new KryoBase
     k.setRegistrationRequired(false)
-    k.setInstantiatorStrategy(new org.objenesis.strategy.StdInstantiatorStrategy)
+    k.setInstantiatorStrategy(new com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy)
 
     // Handle cases where we may have an odd classloader setup like with libjars
     // for hadoop

--- a/chill-scala/src/main/scala/com/twitter/chill/config/ReflectingInstantiatorBuilder.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/config/ReflectingInstantiatorBuilder.scala
@@ -19,8 +19,8 @@ package com.twitter.chill.config
 import com.twitter.chill._
 
 import com.esotericsoftware.kryo.Kryo;
-import org.objenesis.strategy.InstantiatorStrategy;
-import org.objenesis.strategy.StdInstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.InstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
 
 import scala.collection.JavaConverters._
 

--- a/chill-scala/src/test/scala/com/twitter/chill/config/ReflectingInstantiatorTest.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/config/ReflectingInstantiatorTest.scala
@@ -20,8 +20,8 @@ import org.scalatest._
 
 import com.twitter.chill.config._
 
-import org.objenesis.strategy.InstantiatorStrategy;
-import org.objenesis.strategy.StdInstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.InstantiatorStrategy;
+import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
 
 class ReflectingInstantiatorTest extends WordSpec with Matchers {
   "A ReflectingInstantiator" should {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,7 +10,7 @@ import com.typesafe.sbt.SbtScalariform._
 import scala.collection.JavaConverters._
 
 object ChillBuild extends Build {
-  val kryoVersion = "2.21"
+  val kryoVersion = "2.22"
 
   val bijectionVersion = "0.8.1"
   val algebirdVersion = "0.11.0"


### PR DESCRIPTION
This is a patch which moves Chill up to Kryo 2-22; so giving chill and scala a version of scala consistent with hive 1.2.x

see https://github.com/twitter/chill/pull/230 for related discussions on a move to kryo 3, which is probably a more traumatic event