### PR TITLE
Serializers for unmodifiable Java collections 0.7.x

### DIFF
--- a/chill-java/src/main/java/com/twitter/chill/java/PackageRegistrar.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/PackageRegistrar.java
@@ -26,20 +26,27 @@ import java.util.ArrayList;
  * Creates a registrar for all the serializers in the chill.java package
  */
 public class PackageRegistrar {
-
+  
   static public IKryoRegistrar all() {
     return new IterableRegistrar(
-      ArraysAsListSerializer.registrar(),
-      BitSetSerializer.registrar(),
-      PriorityQueueSerializer.registrar(),
-      RegexSerializer.registrar(),
-      SqlDateSerializer.registrar(),
-      SqlTimeSerializer.registrar(),
-      TimestampSerializer.registrar(),
-      URISerializer.registrar(),
-      InetSocketAddressSerializer.registrar(),
-      UUIDSerializer.registrar(),
-      LocaleSerializer.registrar(),
-      SimpleDateFormatSerializer.registrar());
+        ArraysAsListSerializer.registrar(),
+        BitSetSerializer.registrar(),
+        PriorityQueueSerializer.registrar(),
+        RegexSerializer.registrar(),
+        SqlDateSerializer.registrar(),
+        SqlTimeSerializer.registrar(),
+        TimestampSerializer.registrar(),
+        URISerializer.registrar(),
+        InetSocketAddressSerializer.registrar(),
+        UUIDSerializer.registrar(),
+        LocaleSerializer.registrar(),
+        SimpleDateFormatSerializer.registrar(),
+        UnmodifiableCollectionSerializer.registrar(),
+        UnmodifiableListSerializer.registrar(),
+        UnmodifiableMapSerializer.registrar(),
+        UnmodifiableSetSerializer.registrar(),
+        UnmodifiableSortedMapSerializer.registrar(),
+        UnmodifiableSortedSetSerializer.registrar()
+    );
   }
 }

--- a/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableCollectionSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableCollectionSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.twitter.chill.IKryoRegistrar;
+import com.twitter.chill.SingleRegistrar;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+/**
+ * A kryo {@link Serializer} for unmodifiable collections created via {@link Collections#unmodifiableCollection(Collection)}.
+ * <p>
+ * Note: This serializer does not support cyclic references, so if one of the objects
+ * gets set the list as attribute this might cause an error during deserialization.
+ * </p>
+ *
+ * @author <a href="mailto:alex@chermenin.ru">Alex Chermenin</a>
+ */
+public class UnmodifiableCollectionSerializer extends UnmodifiableJavaCollectionSerializer<Collection<?>> {
+  
+  @SuppressWarnings("unchecked")
+  static public IKryoRegistrar registrar() {
+    return new SingleRegistrar(Collections.unmodifiableCollection(Collections.EMPTY_SET).getClass(),
+        new UnmodifiableCollectionSerializer());
+  }
+  
+  @Override
+  protected Field getInnerField() throws Exception {
+    return Class.forName("java.util.Collections$UnmodifiableCollection").getDeclaredField("c");
+  }
+  
+  @Override
+  protected Collection<?> newInstance(Collection<?> c) {
+    return Collections.unmodifiableCollection(c);
+  }
+}

--- a/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableJavaCollectionSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableJavaCollectionSerializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A kryo base {@link Serializer} for unmodifiable Java collections.
+ * <p>
+ * Note: This serializer does not support cyclic references, so if one of the objects
+ * gets set the list as attribute this might cause an error during deserialization.
+ * </p>
+ *
+ * @author <a href="mailto:alex@chermenin.ru">Alex Chermenin</a>
+ */
+abstract class UnmodifiableJavaCollectionSerializer<T> extends Serializer<T> {
+  
+  abstract protected T newInstance(T o);
+  
+  abstract protected Field getInnerField() throws Exception;
+  
+  final private Field innerField;
+  
+  UnmodifiableJavaCollectionSerializer() {
+    try {
+      innerField = getInnerField();
+      innerField.setAccessible(true);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  @Override
+  @SuppressWarnings("unchecked")
+  public T read(Kryo kryo, Input input, Class<T> type) {
+    try {
+      T u = (T) kryo.readClassAndObject(input);
+      return newInstance(u);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  @Override
+  @SuppressWarnings("unchecked")
+  public void write(Kryo kryo, Output output, T object) {
+    try {
+      T u = (T) innerField.get(object);
+      kryo.writeClassAndObject(output, u);
+    } catch (RuntimeException e) {
+      // Don't eat and wrap RuntimeExceptions because the ObjectBuffer.write...
+      // handles SerializationException specifically (resizing the buffer)...
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableListSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableListSerializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.twitter.chill.IKryoRegistrar;
+import com.twitter.chill.SingleRegistrar;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+/**
+ * A kryo {@link Serializer} for unmodifiable lists created via {@link Collections#unmodifiableList(List)}.
+ * <p>
+ * Note: This serializer does not support cyclic references, so if one of the objects
+ * gets set the list as attribute this might cause an error during deserialization.
+ * </p>
+ *
+ * @author <a href="mailto:alex@chermenin.ru">Alex Chermenin</a>
+ */
+public class UnmodifiableListSerializer extends UnmodifiableJavaCollectionSerializer<List<?>> {
+  
+  @SuppressWarnings("unchecked")
+  static public IKryoRegistrar registrar() {
+    return new IterableRegistrar(
+        new SingleRegistrar(Collections.unmodifiableList(Collections.EMPTY_LIST).getClass(),
+            new UnmodifiableListSerializer()),
+        new SingleRegistrar(Collections.unmodifiableList(new LinkedList(Collections.EMPTY_LIST)).getClass(),
+            new UnmodifiableListSerializer())
+    );
+  }
+  
+  @Override
+  protected Field getInnerField() throws Exception {
+    return Class.forName("java.util.Collections$UnmodifiableList").getDeclaredField("list");
+  }
+  
+  @Override
+  protected List<?> newInstance(List<?> l) {
+    return Collections.unmodifiableList(l);
+  }
+}

--- a/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableMapSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableMapSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.twitter.chill.IKryoRegistrar;
+import com.twitter.chill.SingleRegistrar;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+/**
+ * A kryo {@link Serializer} for unmodifiable maps created via {@link Collections#unmodifiableMap(Map)}.
+ * <p>
+ * Note: This serializer does not support cyclic references, so if one of the objects
+ * gets set the list as attribute this might cause an error during deserialization.
+ * </p>
+ *
+ * @author <a href="mailto:alex@chermenin.ru">Alex Chermenin</a>
+ */
+public class UnmodifiableMapSerializer extends UnmodifiableJavaCollectionSerializer<Map<?, ?>> {
+  
+  @SuppressWarnings("unchecked")
+  static public IKryoRegistrar registrar() {
+    return new SingleRegistrar(Collections.unmodifiableMap(Collections.EMPTY_MAP).getClass(),
+        new UnmodifiableMapSerializer());
+  }
+  
+  @Override
+  protected Field getInnerField() throws Exception {
+    return Class.forName("java.util.Collections$UnmodifiableMap").getDeclaredField("m");
+  }
+  
+  @Override
+  protected Map<?, ?> newInstance(Map<?, ?> m) {
+    return Collections.unmodifiableMap(m);
+  }
+}

--- a/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableSetSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableSetSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.twitter.chill.IKryoRegistrar;
+import com.twitter.chill.SingleRegistrar;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+/**
+ * A kryo {@link Serializer} for unmodifiable sets created via {@link Collections#unmodifiableSet(Set)}.
+ * <p>
+ * Note: This serializer does not support cyclic references, so if one of the objects
+ * gets set the list as attribute this might cause an error during deserialization.
+ * </p>
+ *
+ * @author <a href="mailto:alex@chermenin.ru">Alex Chermenin</a>
+ */
+public class UnmodifiableSetSerializer extends UnmodifiableJavaCollectionSerializer<Set<?>> {
+  
+  @SuppressWarnings("unchecked")
+  static public IKryoRegistrar registrar() {
+    return new SingleRegistrar(Collections.unmodifiableSet(Collections.EMPTY_SET).getClass(),
+        new UnmodifiableSetSerializer());
+  }
+  
+  @Override
+  protected Field getInnerField() throws Exception {
+    return Class.forName("java.util.Collections$UnmodifiableSet").getSuperclass().getDeclaredField("c");
+  }
+  
+  @Override
+  protected Set<?> newInstance(Set<?> s) {
+    return Collections.unmodifiableSet(s);
+  }
+}

--- a/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableSortedMapSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableSortedMapSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.twitter.chill.IKryoRegistrar;
+import com.twitter.chill.SingleRegistrar;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+/**
+ * A kryo {@link Serializer} for unmodifiable sortable maps created via {@link Collections#unmodifiableSortedMap(SortedMap)}.
+ * <p>
+ * Note: This serializer does not support cyclic references, so if one of the objects
+ * gets set the list as attribute this might cause an error during deserialization.
+ * </p>
+ *
+ * @author <a href="mailto:alex@chermenin.ru">Alex Chermenin</a>
+ */
+public class UnmodifiableSortedMapSerializer extends UnmodifiableJavaCollectionSerializer<SortedMap<?, ?>> {
+  
+  @SuppressWarnings("unchecked")
+  static public IKryoRegistrar registrar() {
+    return new SingleRegistrar(Collections.unmodifiableSortedMap(new TreeMap(Collections.EMPTY_MAP)).getClass(),
+        new UnmodifiableSortedMapSerializer());
+  }
+  
+  @Override
+  protected Field getInnerField() throws Exception {
+    return Class.forName("java.util.Collections$UnmodifiableSortedMap").getDeclaredField("sm");
+  }
+  
+  @Override
+  protected SortedMap<?, ?> newInstance(SortedMap<?, ?> m) {
+    return Collections.unmodifiableSortedMap(m);
+  }
+}

--- a/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableSortedSetSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/UnmodifiableSortedSetSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.twitter.chill.IKryoRegistrar;
+import com.twitter.chill.SingleRegistrar;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+/**
+ * A kryo {@link Serializer} for unmodifiable sortable sets created via {@link Collections#unmodifiableSortedSet(SortedSet)}.
+ * <p>
+ * Note: This serializer does not support cyclic references, so if one of the objects
+ * gets set the list as attribute this might cause an error during deserialization.
+ * </p>
+ *
+ * @author <a href="mailto:alex@chermenin.ru">Alex Chermenin</a>
+ */
+public class UnmodifiableSortedSetSerializer extends UnmodifiableJavaCollectionSerializer<SortedSet<?>> {
+  
+  @SuppressWarnings("unchecked")
+  static public IKryoRegistrar registrar() {
+    return new SingleRegistrar(Collections.unmodifiableSortedSet(new TreeSet(Collections.EMPTY_SET)).getClass(),
+        new UnmodifiableSortedSetSerializer());
+  }
+  
+  @Override
+  protected Field getInnerField() throws Exception {
+    return Class.forName("java.util.Collections$UnmodifiableSortedSet").getDeclaredField("ss");
+  }
+  
+  @Override
+  protected SortedSet<?> newInstance(SortedSet<?> s) {
+    return Collections.unmodifiableSortedSet(s);
+  }
+}

--- a/chill-java/src/test/java/com/twitter/chill/java/TestCollections.java
+++ b/chill-java/src/test/java/com/twitter/chill/java/TestCollections.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.util.*;
+
+@SuppressWarnings("unchecked")
+public class TestCollections {
+
+    private static final Kryo kryo = new Kryo();
+
+    private static final List<Integer> test_list = Arrays.asList(1, 2, 3, 4);
+
+    private static final Set<Integer> test_set = new HashSet<Integer>(test_list);
+
+    private static final Map<Integer, String> test_map = new HashMap<Integer, String>();
+
+    static {
+        PackageRegistrar.all().apply(kryo);
+
+        test_map.put(1, "one");
+        test_map.put(2, "two");
+        test_map.put(3, "three");
+        test_map.put(4, "four");
+    }
+
+    public static <T> T serializeAndDeserialize(T t) {
+        Output output = new Output(1000, -1);
+        kryo.writeClassAndObject(output, t);
+        Input input = new Input(output.toBytes());
+        return (T) kryo.readClassAndObject(input);
+    }
+
+    public static Collection<?> getUnmodifiableCollection() {
+        return Collections.unmodifiableCollection(new ArrayList<Integer>(test_list));
+    }
+
+    public static List<?> getUnmodifiableArrayList() {
+        return Collections.unmodifiableList(new ArrayList<Integer>(test_list));
+    }
+
+    public static List<?> getUnmodifiableLinkedList() {
+        return Collections.unmodifiableList(new LinkedList<Integer>(test_list));
+    }
+
+    public static Map<?, ?> getUnmodifiableHashMap() {
+        return Collections.unmodifiableMap(test_map);
+    }
+
+    public static Map<?, ?> getUnmodifiableTreeMap() {
+        return Collections.unmodifiableSortedMap(new TreeMap<Integer, String>(test_map));
+    }
+
+    public static Set<?> getUnmodifiableHashSet() {
+        return Collections.unmodifiableSet(test_set);
+    }
+
+    public static Set<?> getUnmodifiableTreeSet() {
+        return Collections.unmodifiableSortedSet(new TreeSet<Integer>(test_set));
+    }
+
+    public static List<?> getEmptyList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<?, ?> getEmptyMap() {
+        return Collections.emptyMap();
+    }
+
+    public static Set<?> getEmptySet() {
+        return Collections.emptySet();
+    }
+}

--- a/chill-java/src/test/scala/com/twitter/chill/java/UnmodifiableCollectionsTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/UnmodifiableCollectionsTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Alex Chermenin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.twitter.chill.java
+
+import TestCollections._
+import org.scalatest._
+
+class UnmodifiableCollectionsTest extends WordSpec with Matchers {
+
+  "UnmodifiableListSerializer" should {
+
+    "UnmodifiableArrayList" in {
+      val list = getUnmodifiableArrayList
+      list should equal(serializeAndDeserialize(list))
+    }
+
+    "UnmodifiableLinkedList" in {
+      val list = getUnmodifiableLinkedList
+      list should equal(serializeAndDeserialize(list))
+    }
+  }
+
+  "UnmodifiableMapSerializer" should {
+
+    "UnmodifiableHashMap" in {
+      val map = getUnmodifiableHashMap
+      map should equal(serializeAndDeserialize(map))
+    }
+  }
+
+  "UnmodifiableSortedMapSerializer" should {
+
+    "UnmodifiableTreeMap" in {
+      val map = getUnmodifiableTreeMap
+      map should equal(serializeAndDeserialize(map))
+    }
+  }
+
+  "UnmodifiableSetSerializer" should {
+
+    "UnmodifiableHashSet" in {
+      val set = getUnmodifiableHashSet
+      set should equal(serializeAndDeserialize(set))
+    }
+  }
+
+  "UnmodifiableSortedSetSerializer" should {
+
+    "UnmodifiableTreeSet" in {
+      val set = getUnmodifiableTreeSet
+      set should equal(serializeAndDeserialize(set))
+    }
+  }
+
+  "UnmodifiableCollectionSerializer" should {
+
+    "UnmodifiableCollection" in {
+      val before = getUnmodifiableCollection
+      val after = serializeAndDeserialize(before)
+
+      // UnmodifiableCollection has not own equals() method
+      before.getClass should equal(after.getClass)
+      Set(before.toArray: _*)
+        .zip(Set(after.toArray: _*))
+        .count(x => !x._1.equals(x._2)) should equal(0)
+    }
+  }
+}


### PR DESCRIPTION
This is the 0.7.x version of #260
- Serializers for unmodifiable and empty collections.

Added serializers for collections created via
Collections.unmodifiable...() and Collections.empty...() methods.
- Some refactoring.

Serializers of unmodifiable Java collections was refactored.
Deleted serializers for empty collections (Kryo has default serializators for it).
