### PR TITLE
Upgrade to Storm API 1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -174,11 +174,7 @@ lazy val chillJava = module("java").settings(
 lazy val chillStorm = module("storm").settings(
   crossPaths := false,
   autoScalaLibrary := false,
-  resolvers ++= Seq(
-    "Clojars Repository" at "http://clojars.org/repo",
-    "Conjars Repository" at "http://conjars.org/repo"
-  ),
-  libraryDependencies += "storm" % "storm" % "0.9.0-wip9" % "provided"
+  libraryDependencies += "org.apache.storm" % "storm-core" % "1.0.2" % "provided"
 ).dependsOn(chillJava)
 
 // This can only have java deps!

--- a/chill-storm/src/main/java/com/twitter/chill/storm/BlizzardKryoFactory.java
+++ b/chill-storm/src/main/java/com/twitter/chill/storm/BlizzardKryoFactory.java
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.chill.storm;
 
-import backtype.storm.serialization.IKryoFactory;
+import org.apache.storm.serialization.IKryoFactory;
 import com.esotericsoftware.kryo.Kryo;
 import java.util.Map;
 


### PR DESCRIPTION
Support modern Storm API in chill-storm module.

This is https://github.com/twitter/chill/pull/268 PR but for develop branch.