### PR TITLE
Build the docs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
 
     - scala: 2.12.1
       jdk: oraclejdk8
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
+      #script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION doc"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean test mimaReportBinaryIssues
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" # "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
 
     - scala: 2.11.8
       jdk: oraclejdk8
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
+      script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues doc
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 
     - scala: 2.12.1
       jdk: oraclejdk8
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" # "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" # "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 matrix:
   include:
     - scala: 2.10.6
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" # "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
 
     - scala: 2.11.8
       jdk: oraclejdk8
@@ -13,7 +13,7 @@ matrix:
 
     - scala: 2.12.1
       jdk: oraclejdk8
-      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" # "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
+      script: ./sbt "+++$TRAVIS_SCALA_VERSION clean" "+++$TRAVIS_SCALA_VERSION test" "+++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "+++$TRAVIS_SCALA_VERSION doc"
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,7 @@ val unreleasedModules = Set[String]("akka")
 val javaOnly = Set[String]("storm", "java", "hadoop", "thrift", "protobuf")
 val binaryCompatVersion = "0.8.1"
 
-def youngestForwardCompatible(subProj: String) =
+def youngestForwardCompatible(subProj: String, scalaver: String) =
   Some(subProj)
     .filterNot(unreleasedModules.contains(_))
     .map { s =>
@@ -135,6 +135,7 @@ def youngestForwardCompatible(subProj: String) =
     else
       "com.twitter" %% ("chill-" + s) % binaryCompatVersion
   }
+  .filterNot(_ => scalaver.startsWith("2.12")) // 2.12 0.8.1 was not there
 
 val ignoredABIProblems = {
   import com.typesafe.tools.mima.core._
@@ -148,7 +149,7 @@ def module(name: String) = {
   val id = "chill-%s".format(name)
   Project(id = id, base = file(id), settings = sharedSettings ++ Seq(
     Keys.name := id,
-    mimaPreviousArtifacts := youngestForwardCompatible(name).toSet,
+    mimaPreviousArtifacts := youngestForwardCompatible(name, scalaVersion.value).toSet,
     mimaBinaryIssueFilters ++= ignoredABIProblems,
     // Disable cross publishing for java artifacts
     publishArtifact :=

--- a/build.sbt
+++ b/build.sbt
@@ -126,16 +126,15 @@ val unreleasedModules = Set[String]("akka")
 val javaOnly = Set[String]("storm", "java", "hadoop", "thrift", "protobuf")
 val binaryCompatVersion = "0.8.1"
 
-def youngestForwardCompatible(subProj: String, scalaver: String) =
+def youngestForwardCompatible(subProj: String) =
   Some(subProj)
     .filterNot(unreleasedModules.contains(_))
     .map { s =>
-    if (javaOnly.contains(s))
-      "com.twitter" % ("chill-" + s) % binaryCompatVersion
-    else
-      "com.twitter" %% ("chill-" + s) % binaryCompatVersion
-  }
-  .filterNot(_ => scalaver.startsWith("2.12")) // 2.12 0.8.1 was not there
+      if (javaOnly.contains(s))
+        "com.twitter" % ("chill-" + s) % binaryCompatVersion
+      else
+        "com.twitter" %% ("chill-" + s) % binaryCompatVersion
+    }
 
 val ignoredABIProblems = {
   import com.typesafe.tools.mima.core._
@@ -149,7 +148,7 @@ def module(name: String) = {
   val id = "chill-%s".format(name)
   Project(id = id, base = file(id), settings = sharedSettings ++ Seq(
     Keys.name := id,
-    mimaPreviousArtifacts := youngestForwardCompatible(name, scalaVersion.value).toSet,
+    mimaPreviousArtifacts := youngestForwardCompatible(name).toSet,
     mimaBinaryIssueFilters ++= ignoredABIProblems,
     // Disable cross publishing for java artifacts
     publishArtifact :=

--- a/chill-java/src/main/java/com/twitter/chill/java/ClosureSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/ClosureSerializer.java
@@ -31,11 +31,11 @@ import com.esotericsoftware.kryo.io.Output;
  * <code>
  * kryo.register(java.lang.invoke.SerializedLambda.class);<br>
  * kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());</code>
- * @author Roman Levenstein <romixlev@gmail.com> */
+ * @author Roman Levenstein romixlev@gmail.com */
 public class ClosureSerializer extends Serializer {
 
-	/** Marker class to bind ClosureSerializer to. See also {@link Kryo#isClosure(Class)} and
-	 * {@link Kryo#getRegistration(Class)} */
+	/** Marker class to bind ClosureSerializer to. See also Kryo#isClosure(Class) and
+	 * Kryo#getRegistration(Class) */
 	@SuppressWarnings("javadoc")
 	public static class Closure {
 	}


### PR DESCRIPTION
publishing needs to build docs. Looks like some javadocs are currently broken. This adds building docs to travis (which I think will fail for 2.10) and then I'll get this green.

Need to also do this for 0.7.x and develop.