### PR TITLE
Bump scrooge 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,9 +170,17 @@ lazy val chill = Project(
 
 def akka(scalaVersion: String) =
   (scalaVersion match {
-    case "2.10.6"   => "com.typesafe.akka" %% "akka-actor" % "2.3.16"
+    case s if s.startsWith("2.10.") => "com.typesafe.akka" %% "akka-actor" % "2.3.16"
     case _ => "com.typesafe.akka" %% "akka-actor" % akkaVersion
   }) % "provided"
+
+def scrooge(scalaVersion: String) = {
+  val scroogeBase = "com.twitter" %% "scrooge-serializer"
+  scalaVersion match {
+    case s if s.startsWith("2.10.") => scroogeBase % "4.7.0" // the last 2.10 version
+    case _ => scroogeBase % scroogeVersion
+  }
+}
 
 lazy val chillAkka = module("akka").settings(
   resolvers += Resolver.typesafeRepo("releases"),
@@ -224,7 +232,7 @@ lazy val chillThrift = module("thrift").settings(
 lazy val chillScrooge = module("scrooge").settings(
   libraryDependencies ++= Seq(
     "org.apache.thrift" % "libthrift" % "0.6.1" exclude("junit", "junit"),
-    "com.twitter" %% "scrooge-serializer" % scroogeVersion
+    scalaVersion (sv => scrooge(sv)).value
   )
 ).dependsOn(chill % "test->test;compile->compile")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import sbtrelease.ReleaseStateTransformations._
 
-val kryoVersion = "4.0.0"
-val bijectionVersion = "0.9.4"
-val algebirdVersion = "0.12.0"
 val akkaVersion = "2.4.16"
+val algebirdVersion = "0.12.0"
+val bijectionVersion = "0.9.4"
+val kryoVersion = "4.0.0"
+val scroogeVersion = "4.12.0"
 
 val sharedSettings = mimaDefaultSettings ++ scalariformSettings ++ Seq(
   organization := "com.twitter",
@@ -221,10 +222,9 @@ lazy val chillThrift = module("thrift").settings(
 )
 
 lazy val chillScrooge = module("scrooge").settings(
-  crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.12")),
   libraryDependencies ++= Seq(
     "org.apache.thrift" % "libthrift" % "0.6.1" exclude("junit", "junit"),
-    "com.twitter" %% "scrooge-serializer" % "3.20.0"
+    "com.twitter" %% "scrooge-serializer" % scroogeVersion
   )
 ).dependsOn(chill % "test->test;compile->compile")
 


### PR DESCRIPTION
this moves scrooge to 4.12.0. We still need algebird to do a full publish.