### PR TITLE
Fix extra allocation + copy in SerDeState

### DIFF
--- a/chill-java/src/main/java/com/twitter/chill/SerDeState.java
+++ b/chill-java/src/main/java/com/twitter/chill/SerDeState.java
@@ -66,7 +66,7 @@ public class SerDeState {
   public byte[] outputToBytes() { return output.toBytes(); }
   // There for ByteArrayOutputStream cases this can be optimized
   public void writeOutputTo(OutputStream os) throws IOException {
-    os.write(outputToBytes());
+    os.write(output.getBuffer(), 0, output.position());
   }
 
   public boolean hasRegistration(Class obj) {

--- a/chill-java/src/test/scala/com/twitter/chill/java/SerDeStateTest.scala
+++ b/chill-java/src/test/scala/com/twitter/chill/java/SerDeStateTest.scala
@@ -1,0 +1,23 @@
+package com.twitter.chill.java
+
+import java.io.ByteArrayOutputStream
+
+import com.twitter.chill.{ KryoInstantiator, KryoPool }
+import org.scalatest.{ Matchers, WordSpec }
+
+class SerDeStateTest extends WordSpec with Matchers {
+  "SerDeState" should {
+    "Properly write out to a Stream" in {
+      val pool = KryoPool.withBuffer(1, new KryoInstantiator, 1000, -1)
+      val st = pool.borrow()
+
+      st.writeClassAndObject("Hello World")
+      val baos = new ByteArrayOutputStream
+      st.writeOutputTo(baos)
+
+      st.clear()
+      st.setInput(baos.toByteArray)
+      st.readClassAndObject() should equal("Hello World")
+    }
+  }
+}


### PR DESCRIPTION
There appears to be no coverage of `writeOutputTo`, so I added something simple to explicitly test it.