### PR TITLE
Clean closures transitively.

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/ClosureCleaner.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ClosureCleaner.scala
@@ -30,185 +30,63 @@
 
 package com.twitter.chill
 
-import _root_.java.lang.reflect.Field
+import _root_.java.lang.reflect.{Constructor, Field}
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable.{ Set => MSet, Map => MMap }
+import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.Opcodes._
+import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Type}
 
 import scala.annotation.tailrec
+import scala.collection.mutable.{Map => MMap, Set => MSet, Stack => MStack}
+import scala.util.Try
 
-import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.{ ClassReader, MethodVisitor, Type, ClassVisitor }
-import com.esotericsoftware.reflectasm.shaded.org.objectweb.asm.Opcodes._
-
-/**
- * Copied from Spark, written by Matei Zaharia (matei@cs.berkeley.edu).
- *
- * Ported to ASM 4.0 and refactored for scalding/summingbird by Oscar Boykin
- *
- * Original code: https://github.com/mesos/spark/blob/master/core/src/main/scala/spark/ClosureCleaner.scala
- */
 object ClosureCleaner {
-  val OUTER = "$outer"
-
-  // Here are the caches for the stuff that depends only on Class[_]
-  // TODO maybe these should be thread-local for thread safety
-  private val outerFields = MMap[Class[_], Option[Field]]()
-  private val outerClassHier = MMap[Class[_], List[Class[_]]]()
-  private val innerClasses = MMap[Class[_], Set[Class[_]]]()
-  private val accessedFieldsMap = MMap[Class[_], Set[Field]]()
-
-  private def getClassReader(cls: Class[_]): ClassReader = {
-    val className = cls.getName.replaceFirst("^.*\\.", "") + ".class"
-    new ClassReader(cls.getResourceAsStream(className))
+  /** Clean the closure in place. */
+  def apply[T <: AnyRef](func: T): T = {
+    new TransitiveClosureCleaner(func).clean
+    func
   }
+}
 
-  // Return the $outer field for this class
-  def outerFieldOf(c: Class[_]): Option[Field] =
-    outerFields
-      .getOrElseUpdate(c,
-        c.getDeclaredFields.find { _.getName == OUTER })
+trait ClosureCleaner {
+  /** The closure to clean. */
+  val func: AnyRef
+  val funcClass: Class[_] = func.getClass
+  val objectCtor: Constructor[_] = classOf[_root_.java.lang.Object].getDeclaredConstructor()
+  final val OUTER = "$outer"
 
-  /**
-   * this does reflection each time
-   * since Class objects are assumed to be immutable, we cache this result
-   */
-  @tailrec
-  private def getOuterClassesFn(cls: Class[_], hierarchy: List[Class[_]] = Nil): List[Class[_]] =
-    outerFieldOf(cls) match {
-      case None => hierarchy
-      case Some(f) => {
-        val next = f.getType
-        getOuterClassesFn(next, next :: hierarchy)
-      }
-    }
-
-  def outerClassesOf(cls: Class[_]): List[Class[_]] =
-    outerClassHier.getOrElseUpdate(cls, getOuterClassesFn(cls))
-
-  /**
-   * returns the (Class, AnyRef) pair from highest level to lowest level
-   * so result.last is the outer of obj.
-   */
-  @tailrec
-  def getOutersOf(obj: AnyRef, hierarchy: List[(Class[_], AnyRef)] = Nil): List[(Class[_], AnyRef)] =
-    outerFieldOf(obj.getClass) match {
-      case None => hierarchy // We have finished
-      case Some(f) => {
-        // f is the $outer of obj
-        f.setAccessible(true)
-        // myOuter = obj.$outer
-        val myOuter = f.get(obj)
-        // This is (Class[T], T) into the hierarchy:
-        // Note that if you use f.getType you might get an interface. No good
-        val outerType = myOuter.getClass
-        getOutersOf(myOuter, (outerType, myOuter) :: hierarchy)
-      }
-    }
-
-  private def getInnerClassesFn(inCls: Class[_]): Set[Class[_]] = {
-    val seen = MSet[Class[_]](inCls)
-    var stack = List[Class[_]](inCls)
-    while (!stack.isEmpty) {
-      val cr = getClassReader(stack.head)
-      stack = stack.tail
-      val set = MSet[Class[_]]()
-      cr.accept(new InnerClosureFinder(set), 0)
-      for (cls <- set -- seen) {
-        seen += cls
-        stack = cls :: stack
-      }
-    }
-    (seen - inCls).toSet
-  }
-
-  def innerClassesOf(cls: Class[_]): Set[Class[_]] =
-    innerClasses.getOrElseUpdate(cls, getInnerClassesFn(cls))
-
-  private def getAccessedFields(cls: Class[_]): MMap[Class[_], MSet[String]] = {
-    val af = outerClassesOf(cls)
-      .foldLeft(MMap[Class[_], MSet[String]]()) { (m, clazz) =>
-        m += ((clazz, MSet[String]()))
-      }
-
-    (innerClassesOf(cls) + cls).foreach { cls =>
-      getClassReader(cls).accept(new FieldAccessFinder(af), 0)
-    }
-    af
+  /** Clean [[func]] by replacing its 'outer' with a cleaned clone. See [[cleanOuter()]]. */
+  def clean: AnyRef = {
+    val newOuter = cleanOuter()
+    setOuter(func, newOuter)
+    func
   }
 
   /**
-   * Uses ASM to return the names of the fields accessed by this cls
+   * Create a new 'cleaned' copy of [[func]]'s outer, without modifying the original. The cleaned
+   * outer may have null values for fields that are determined to be unneeded in the context
+   * of [[func]].
+   *
+   * @return The cleaned outer.
    */
-  def accessedFieldsOf(cls: Class[_]): Set[Field] = {
-    accessedFieldsMap.get(cls) match {
-      case Some(s) => s
-      case None => {
-        //Compute and store:
-        val af = getAccessedFields(cls)
-        def toF(ss: Set[String]): Set[Field] = ss.map { cls.getDeclaredField(_) }
+  def cleanOuter(): AnyRef
 
-        val s = af.get(cls).map { _.toSet }.getOrElse(Set[String]())
-        // Add all of af:
-        af.foreach { clsMSet =>
-          val set = clsMSet._2.toSet
-          accessedFieldsMap += ((clsMSet._1, toF(set)))
-        }
-        toF(s)
-      }
-    }
-  }
+  def outerFieldOf(c: Class[_]): Option[Field] = Try(c.getDeclaredField(OUTER)).toOption
 
-  def apply(obj: AnyRef): Unit = {
-    val newCleanedOuter = allocCleanedOuter(obj)
-    // I know the cool kids use Options, but this code
-    // will avoid an allocation in the usual case of
-    // no $outer
-    setOuter(obj, newCleanedOuter)
-  }
-
-  /**
-   * Return a new bottom-most $outer instance of this obj
-   * with only the accessed fields set in the $outer parent chain
-   */
-  private def allocCleanedOuter(in: AnyRef): AnyRef =
-    // Go top down filling in the actual accessed fields:
-    getOutersOf(in)
-      // the outer-most-outer is null:
-      .foldLeft(null: AnyRef) { (prevOuter, clsData) =>
-        val (thisOuterCls, realOuter) = clsData
-        // create a new outer class that does not have the constructor
-        // called on it.
-        val nextOuter = instantiateClass(thisOuterCls);
-        // We are populate its $outer variable with the
-        // previous outer, and then we go down, and set the accessed
-        // fields below:
-        setOuter(nextOuter, prevOuter)
-        // for each of the accessed fields of this class
-        // set the fields from the parents of in:
-        accessedFieldsOf(thisOuterCls)
-          .foreach { setFromTo(_, realOuter, nextOuter) }
-        // Now return this populated object for the next outer instance to use
-        nextOuter
-      }
-
-  // Set the given field in newv to the same value as old
-  private def setFromTo(f: Field, old: AnyRef, newv: AnyRef) {
-    f.setAccessible(true)
-    val accessedValue = f.get(old)
-    f.set(newv, accessedValue)
-  }
-
-  private def setOuter(obj: AnyRef, outer: AnyRef) {
-    if (null != outer) {
+  def setOuter(obj: AnyRef, outer: AnyRef): Unit = {
+    if (outer != null) {
       val field = outerFieldOf(obj.getClass).get
       field.setAccessible(true)
       field.set(obj, outer)
     }
   }
 
-  private val objectCtor = classOf[_root_.java.lang.Object].getDeclaredConstructor();
-  // Use reflection to instantiate object without calling constructor
-  private def instantiateClass(cls: Class[_]): AnyRef =
+  def copyField(f: Field, old: AnyRef, newv: AnyRef): Unit = {
+    f.setAccessible(true)
+    val accessedValue = f.get(old)
+    f.set(newv, accessedValue)
+  }
+
+  def instantiateClass(cls: Class[_]): AnyRef =
     sun.reflect.ReflectionFactory
       .getReflectionFactory
       .newConstructorForSerialization(cls, objectCtor)
@@ -216,49 +94,155 @@ object ClosureCleaner {
       .asInstanceOf[AnyRef]
 }
 
-class FieldAccessFinder(output: MMap[Class[_], MSet[String]]) extends ClassVisitor(ASM5) {
+/**
+ * An implementation of [[ClosureCleaner]] that cleans [[func]] by transitively tracing its method
+ * calls and field references up through its enclosing scopes. A new hierarchy of outers is
+ * constructed by cloning the outer scopes and populating only the fields that are to be accessed
+ * by [[func]] (including any of its inner closures). Additionally, outers are removed from the
+ * new hierarchy if none of their fields are accessed by [[func]].
+ */
+private class TransitiveClosureCleaner(val func: AnyRef) extends ClosureCleaner {
+  private val accessedFieldsMap = MMap[Class[_], Set[Field]]()
+  private lazy val outers: List[(Class[_], AnyRef)] = getOutersOf(func)
+  private lazy val outerClasses: List[Class[_]] = outers.map(_._1)
+
+  override def cleanOuter(): AnyRef = {
+    storeAccessedFields()
+    outers.foldLeft(null: AnyRef) { (prevOuter, clsData) =>
+      val (thisOuterCls, realOuter) = clsData
+      val nextOuter = instantiateClass(thisOuterCls)
+      accessedFieldsMap(thisOuterCls).foreach(copyField(_, realOuter, nextOuter))
+      /* If this object's outer is not transitively referenced from the starting closure
+         (or any of its inner closures), we can null it out. */
+      val parent =
+        if (!accessedFieldsMap(thisOuterCls).exists(_.getName == OUTER)) null else prevOuter
+      setOuter(nextOuter, parent)
+      nextOuter
+    }
+  }
+
+  /**
+   * Returns the (Class, AnyRef) pairs from highest level to lowest level. The last element is the
+   * outer of the closure.
+   */
+  @tailrec
+  private def getOutersOf(obj: AnyRef, hierarchy: List[(Class[_], AnyRef)] = Nil): List[(Class[_], AnyRef)] =
+    outerFieldOf(obj.getClass) match {
+      case None => hierarchy // We have finished
+      case Some(f) =>
+        // f is the $outer of obj
+        f.setAccessible(true)
+        // myOuter = obj.$outer
+        val myOuter = f.get(obj)
+        val outerType = myOuter.getClass
+        getOutersOf(myOuter, (outerType, myOuter) :: hierarchy)
+    }
+
+  private def classReader(cls: Class[_]): ClassReader = {
+    val className = cls.getName.replaceFirst("^.*\\.", "") + ".class"
+    new ClassReader(cls.getResourceAsStream(className))
+  }
+
+  private def innerClasses: Set[Class[_]] = {
+    val seen = MSet[Class[_]](funcClass)
+    val stack = MStack[Class[_]](funcClass)
+    while (stack.nonEmpty) {
+      val cr = classReader(stack.pop())
+      val set = MSet[Class[_]]()
+      cr.accept(new InnerClosureFinder(set), 0)
+      (set -- seen).foreach { cls =>
+        seen += cls
+        stack.push(cls)
+      }
+    }
+    (seen - funcClass).toSet
+  }
+
+  private def getAccessedFields: MMap[Class[_], MSet[String]] = {
+    val af = outerClasses
+      .foldLeft(MMap[Class[_], MSet[String]]()) { (m, cls) =>
+        m += ((cls, MSet[String]()))
+      }
+    (innerClasses + funcClass).foreach(classReader(_).accept(
+      new AccessedFieldsVisitor(af)(classReader), 0))
+    af
+  }
+
+  private def storeAccessedFields(): Unit = {
+    if (accessedFieldsMap.isEmpty) {
+      getAccessedFields.foreach {
+        case (cls, mset) =>
+          def toF(ss: Set[String]): Set[Field] = ss.map(cls.getDeclaredField)
+          val set = mset.toSet
+          accessedFieldsMap += ((cls, toF(set)))
+      }
+    }
+  }
+}
+
+case class MethodIdentifier[T](cls: Class[T], name: String, desc: String)
+
+class AccessedFieldsVisitor(output: MMap[Class[_], MSet[String]],
+                            specificMethod: Option[MethodIdentifier[_]] = None,
+                            visitedMethods: MSet[MethodIdentifier[_]] = MSet.empty)
+                           (clsReader: Class[_] => ClassReader) extends ClassVisitor(ASM5) {
   override def visitMethod(access: Int, name: String, desc: String,
     sig: String, exceptions: Array[String]): MethodVisitor = {
-    return new MethodVisitor(ASM5) {
-      override def visitFieldInsn(op: Int, owner: String, name: String,
-        desc: String) {
-        if (op == GETFIELD)
-          for (cl <- output.keys if cl.getName == owner.replace('/', '.'))
-            output(cl) += name
-      }
+    if (specificMethod.isDefined &&
+      (specificMethod.get.name != name || specificMethod.get.desc != desc)) {
+      null
+    } else {
+      new MethodVisitor(ASM5) {
+        override def visitFieldInsn(op: Int, owner: String, name: String, desc: String): Unit = {
+          if (op == GETFIELD) {
+            for (cl <- output.keys if cl.getName == owner.replace('/', '.')) {
+              output(cl) += name
+            }
+          }
+        }
 
-      override def visitMethodInsn(op: Int, owner: String, name: String,
-        desc: String, itf: Boolean) {
-        // Check for calls a getter method for a variable in an interpreter wrapper object.
-        // This means that the corresponding field will be accessed, so we should save it.
-        if (op == INVOKEVIRTUAL && owner.endsWith("$iwC") && !name.endsWith("$outer"))
-          for (cl <- output.keys if cl.getName == owner.replace('/', '.'))
-            output(cl) += name
+        override def visitMethodInsn(op: Int, owner: String, name: String,
+          desc: String, itf: Boolean): Unit = {
+          for (cl <- output.keys if cl.getName == owner.replace('/', '.')) {
+            // Check for calls a getter method for a variable in an interpreter wrapper object.
+            // This means that the corresponding field will be accessed, so we should save it.
+            if (op == INVOKEVIRTUAL && owner.endsWith("$iwC") && !name.endsWith("$outer")) {
+              output(cl) += name
+            }
+            val m = MethodIdentifier(cl, name, desc)
+            if (!visitedMethods.contains(m)) {
+              // Keep track of visited methods to avoid potential infinite cycles
+              visitedMethods += m
+              clsReader(cl).accept(
+                new AccessedFieldsVisitor(output, Some(m), visitedMethods)(clsReader), 0)
+            }
+          }
+        }
       }
     }
   }
 }
 
 class InnerClosureFinder(output: MSet[Class[_]]) extends ClassVisitor(ASM5) {
-  var myName: String = null
+  var myName: String = _
 
   override def visit(version: Int, access: Int, name: String, sig: String,
-    superName: String, interfaces: Array[String]) {
+    superName: String, interfaces: Array[String]): Unit = {
     myName = name
   }
 
   override def visitMethod(access: Int, name: String, desc: String,
-    sig: String, exceptions: Array[String]): MethodVisitor = {
-    return new MethodVisitor(ASM5) {
+    sig: String, exceptions: Array[String]): MethodVisitor =
+    new MethodVisitor(ASM5) {
       override def visitMethodInsn(op: Int, owner: String, name: String,
         desc: String, itf: Boolean) {
         val argTypes = Type.getArgumentTypes(desc)
-        if (op == INVOKESPECIAL && name == "<init>" && argTypes.length > 0
-          && argTypes(0).toString.startsWith("L") // is it an object?
-          && argTypes(0).getInternalName == myName)
+        if (op == INVOKESPECIAL && name == "<init>" && argTypes.nonEmpty
+          && argTypes(0).toString.startsWith("L")
+          && argTypes(0).getInternalName == myName) {
           output += Class.forName(owner.replace('/', '.'), false,
             Thread.currentThread.getContextClassLoader)
+        }
       }
     }
-  }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/ClosureCleanerSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/ClosureCleanerSpec.scala
@@ -72,23 +72,24 @@ class ClosureCleanerSpec extends WordSpec with Matchers with BaseProperties {
     }
 
     "Handle nested closures in non-serializable object" in {
-      class NestedClosuresNotSerializable {
-        val irrelevantInt: Int = 1
-        def closure(name: String)(body: => Int => Int): Int => Int = body
-        def getMapFn: Int => Int = closure("one") {
-          def x = irrelevantInt
-          def y = 2
-          val fn = { a: Int => a + y }
-          fn
-        }
-      }
-
       val fn = new NestedClosuresNotSerializable().getMapFn
+      isSerializable(fn) shouldBe false
       ClosureCleaner(fn)
       isSerializable(fn) shouldBe true
       fn(6) shouldEqual 8
       val roundTripFn = jrt(fn.asInstanceOf[Serializable]).asInstanceOf[Int => Int]
       roundTripFn(6) shouldEqual 8
+    }
+  }
+
+  class NestedClosuresNotSerializable {
+    val irrelevantInt: Int = 1
+    def closure(name: String)(body: => Int => Int): Int => Int = body
+    def getMapFn: Int => Int = closure("one") {
+      def x = irrelevantInt
+      def y = 2
+      val fn = { a: Int => a + y }
+      fn
     }
   }
 


### PR DESCRIPTION
(Adapted from https://github.com/spotify/scio/pull/698)

`ClosureCleaner` seems to not work as well as it could in certain cases, especially when it comes to multiple layers of nesting. For example it's possible to have a closure whose enclosing scope references an outer that is not serializable, but such that (by tracing the transitive method calls / field references starting from the inner closure), we don't actually need the reference, so we can null it out. The test case I added to ClosureTest is an example of this.

