### PR TITLE
Bump kryo to 4.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtrelease.ReleaseStateTransformations._
 val akkaVersion = "2.4.16"
 val algebirdVersion = "0.13.0"
 val bijectionVersion = "0.9.4"
-val kryoVersion = "4.0.0"
+val kryoVersion = "4.0.1"
 val scroogeVersion = "4.12.0"
 
 val sharedSettings = mimaDefaultSettings ++ scalariformSettings ++ Seq(


### PR DESCRIPTION
Because of https://github.com/EsotericSoftware/kryo/releases/tag/kryo-parent-4.0.1 and mostly https://github.com/EsotericSoftware/kryo/pull/516