### PR TITLE
add QTreeSerializer

### DIFF
--- a/chill-algebird/src/main/scala/com/twitter/chill/algebird/AlgebirdRegistrar.scala
+++ b/chill-algebird/src/main/scala/com/twitter/chill/algebird/AlgebirdRegistrar.scala
@@ -27,6 +27,7 @@ import com.twitter.algebird.{
   HyperLogLog,
   HyperLogLogMonoid,
   Moments,
+  QTree,
   SpaceSaver,
   DenseVector,
   SparseVector,
@@ -41,6 +42,7 @@ class AlgebirdRegistrar extends IKryoRegistrar {
     k.register(classOf[DecayedValue], new DecayedValueSerializer)
     k.register(classOf[HyperLogLogMonoid], new HLLMonoidSerializer)
     k.register(classOf[Moments], new MomentsSerializer)
+    k.register(classOf[QTree[Any]], new QTreeSerializer)
     k.addDefaultSerializer(classOf[HLL], new HLLSerializer)
 
     /**

--- a/chill-algebird/src/main/scala/com/twitter/chill/algebird/AlgebirdSerializers.scala
+++ b/chill-algebird/src/main/scala/com/twitter/chill/algebird/AlgebirdSerializers.scala
@@ -26,6 +26,7 @@ import com.twitter.algebird.{
   HyperLogLog,
   HyperLogLogMonoid,
   Moments,
+  QTree,
   SpaceSaver,
   SSOne,
   SSMany
@@ -93,5 +94,25 @@ class HLLMonoidSerializer extends KSerializer[HyperLogLogMonoid] {
   def read(kser: Kryo, in: Input, cls: Class[HyperLogLogMonoid]): HyperLogLogMonoid = {
     val bits = in.readInt(true)
     hllMonoids.getOrElseUpdate(bits, new HyperLogLogMonoid(bits))
+  }
+}
+
+class QTreeSerializer extends KSerializer[QTree[Any]] {
+  setImmutable(true)
+  override def read(kryo: Kryo, input: Input, cls: Class[QTree[Any]]): QTree[Any] = {
+    val (v1, v2, v3) = (input.readLong(), input.readInt(), input.readLong())
+    val v4 = kryo.readClassAndObject(input)
+    val v5 = kryo.readClassAndObject(input).asInstanceOf[Option[QTree[Any]]]
+    val v6 = kryo.readClassAndObject(input).asInstanceOf[Option[QTree[Any]]]
+    QTree(v1, v2, v3, v4, v5, v6)
+  }
+
+  override def write(kryo: Kryo, output: Output, obj: QTree[Any]): Unit = {
+    output.writeLong(obj._1)
+    output.writeInt(obj._2)
+    output.writeLong(obj._3)
+    kryo.writeClassAndObject(output, obj._4)
+    kryo.writeClassAndObject(output, obj._5)
+    kryo.writeClassAndObject(output, obj._6)
   }
 }

--- a/chill-algebird/src/test/scala/com/twitter/chill/algebird/AlgebirdSerializersSpec.scala
+++ b/chill-algebird/src/test/scala/com/twitter/chill/algebird/AlgebirdSerializersSpec.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.chill.algebird
 
 import com.twitter.chill.{ KSerializer, ScalaKryoInstantiator, KryoPool }
-import com.twitter.algebird.{ AveragedValue, DecayedValue, HyperLogLogMonoid, MomentsGroup, AdaptiveVector }
+import com.twitter.algebird.{ AveragedValue, DecayedValue, HyperLogLogMonoid, MomentsGroup, AdaptiveVector, QTree }
 import org.scalatest._
 
 class AlgebirdSerializersSpec extends WordSpec with Matchers {
@@ -61,6 +61,10 @@ class AlgebirdSerializersSpec extends WordSpec with Matchers {
 
     "serialize and deserialize Moments" in {
       roundtrip(MomentsGroup.zero)
+    }
+
+    "serialize and deserialize QTree" in {
+      roundtrip(QTree(1.0))
     }
 
     "serialize and deserialize HLL" in {


### PR DESCRIPTION
Default kryo serialization for `QTree` is not deterministic due to other fields in the class, and this causes problem in some frameworks like Apache Beam which detects mutation of input element via serialization.