### PR TITLE
Add deterministic serializer for BigDecimal

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/BigDecimalSerializer.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/BigDecimalSerializer.scala
@@ -1,0 +1,31 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.chill
+
+import _root_.java.math.{ BigDecimal => JBigDecimal }
+import _root_.scala.math.BigDecimal
+
+private class BigDecimalSerializer extends KSerializer[BigDecimal] {
+  override def read(kryo: Kryo, input: Input, cls: Class[BigDecimal]): BigDecimal = {
+    val jBigDec = kryo.readClassAndObject(input).asInstanceOf[JBigDecimal]
+    BigDecimal(jBigDec)
+  }
+
+  override def write(kryo: Kryo, output: Output, obj: BigDecimal): Unit = {
+    kryo.writeClassAndObject(output, obj.bigDecimal)
+  }
+}

--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -106,6 +106,7 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forSubclass[WrappedArray[Any]](new WrappedArraySerializer[Any])
       .forSubclass[BitSet](new BitSetSerializer)
       .forSubclass[SortedSet[Any]](new SortedSetSerializer)
+      .forClass[BigDecimal](new BigDecimalSerializer)
       .forClass[Some[Any]](new SomeSerializer[Any])
       .forClass[Left[Any, Any]](new LeftSerializer[Any, Any])
       .forClass[Right[Any, Any]](new RightSerializer[Any, Any])

--- a/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/KryoSpec.scala
@@ -101,7 +101,8 @@ class KryoSpec extends WordSpec with Matchers with BaseProperties {
         new _root_.java.util.ArrayList(Seq(1, 2, 3).asJava).asScala,
         new _root_.java.util.HashMap[Int, Int](Map(1 -> 2, 3 -> 4).asJava).asScala,
         (),
-        'hai)
+        'hai,
+        BigDecimal(1000.24))
         .asInstanceOf[List[AnyRef]]
 
       test.foreach { _ should roundtrip }


### PR DESCRIPTION
Scala's `BigDecimal` class has some stateful fields that result in an encoding that isn't determined by only the value. This causes problems in a framework like Apache Beam where serialized bytes are used to perform mutation checking on values (see https://github.com/spotify/scio/issues/1170).

This PR addresses the problem by registering a deterministic `BigDecimalSerializer`, which simply encodes the underlying Java `BigDecimal` instance, which is immutable.