### PR TITLE
fixed tests broken by PR #312

### DIFF
--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -106,7 +106,6 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forSubclass[WrappedArray[Any]](new WrappedArraySerializer[Any])
       .forSubclass[BitSet](new BitSetSerializer)
       .forSubclass[SortedSet[Any]](new SortedSetSerializer)
-      .forClass[BigDecimal](new BigDecimalSerializer)
       .forClass[Some[Any]](new SomeSerializer[Any])
       .forClass[Left[Any, Any]](new LeftSerializer[Any, Any])
       .forClass[Right[Any, Any]](new RightSerializer[Any, Any])
@@ -190,6 +189,9 @@ class AllScalaRegistrar_0_9_2 extends IKryoRegistrar {
  * Registers all the scala (and java) serializers we have. The registrations are designed to cover most of
  * scala.collecion.immutable, so they can be used in long term persistence scenarios that run with
  * setRegistrationRequired(true).
+ *
+ * When adding new serializers, add them to the end of the list, so compatibility is not broken needlessly
+ * for projects using chill for long term persistence - see com.twitter.chill.RegistrationIdsSpec.
  */
 class AllScalaRegistrar extends IKryoRegistrar {
   def apply(k: Kryo) {
@@ -248,5 +250,6 @@ class AllScalaRegistrar extends IKryoRegistrar {
     k.register(classOf[Stream.Cons[_]], new StreamSerializer[Any])
     k.register(Stream.empty[Any].getClass)
     k.forClass[scala.runtime.VolatileByteRef](new VolatileByteRefSerializer)
+    k.forClass[BigDecimal](new BigDecimalSerializer)
   }
 }

--- a/chill-scala/src/test/scala/com/twitter/chill/RegistrationIdsSpec.scala
+++ b/chill-scala/src/test/scala/com/twitter/chill/RegistrationIdsSpec.scala
@@ -46,7 +46,7 @@ class RegistrationIdsSpec extends WordSpec with Matchers {
          |will fail for $scope, most probably because the order of
          |registration IDs has changed or a registration was added or
          |removed. If that was intended, here is the list of entries
-         |that are currently found, so you can updated the test's
+         |that are currently found, so you can update the test's
          |expected values:
          |
          |${registeredEntries(k)}\n\n\n""".stripMargin)
@@ -198,7 +198,8 @@ class RegistrationIdsSpec extends WordSpec with Matchers {
       |140 -> class scala.collection.immutable.ListMap$Node
       |141 -> class scala.collection.immutable.Stream$Cons
       |142 -> class scala.collection.immutable.Stream$Empty$
-      |143 -> class scala.runtime.VolatileByteRef"""
+      |143 -> class scala.runtime.VolatileByteRef
+      |144 -> class scala.math.BigDecimal"""
       .stripMargin.lines.mkString("\n")
 
   private def expectedEntries_current =


### PR DESCRIPTION
PR #312 registered the serializer for BigDecimal with ID 15, moving all serialization IDs from 15 on one up. This breaks compatibility for projects using chill for long term persistence - see com.twitter.chill.RegistrationIdsSpec which failed just for that reason.

In this commit, the registration of BigDecimal is moved to ID 144 (the end of the list) and the RegistrationIdsSpec is updated accordingly.