### PR TITLE
override protobuf serializer copy method

### DIFF
--- a/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
+++ b/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
@@ -76,5 +76,16 @@ public class ProtobufSerializer extends Serializer<Message> {
       throw new RuntimeException("Could not create " + pbClass, e);
     }
   }
+
+  @Override
+  public Message copy(Kryo kryo, Message original) {
+    try {
+      byte[] bytes = original.toByteArray();
+      return (Message)getParse(original.getClass()).invoke(null, bytes);
+    } catch (Exception exception) {
+      throw new RuntimeException("Copy message error.", exception);
+    }
+  }
+
 }
 


### PR DESCRIPTION
Because the [copy] method in parent class throw KryoException forever, this is very inefficient for protobuf message.