### PR TITLE
Revert "Includes java regex pattern flags to serialization."

### DIFF
--- a/chill-java/src/main/java/com/twitter/chill/java/RegexSerializer.java
+++ b/chill-java/src/main/java/com/twitter/chill/java/RegexSerializer.java
@@ -35,11 +35,10 @@ public class RegexSerializer extends Serializer<Pattern> {
     @Override
     public void write(Kryo kryo, Output output, Pattern pattern) {
         output.writeString(pattern.pattern());
-        output.writeInt(pattern.flags(), true);
     }
 
     @Override
     public Pattern read(Kryo kryo, Input input, Class<Pattern> patternClass) {
-        return Pattern.compile(input.readString(), input.readInt(true));
+        return Pattern.compile(input.readString());
     }
 }


### PR DESCRIPTION
Reverts twitter/chill#326 because it introduced a regression.

```
[info] - should serialize as expected to the correct value (see above for details) *** FAILED ***
[info]   "TgFhKuI[A]" did not equal "TgFhKuI[=]" a*b with serialization id 76 serializes to TgFhKuIA, but the test example is TgFhKuI= (SerializedExamplesOfStandardDataSpec.scala:281)
```