### PR TITLE
Update GHA with scala 2.13.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           - "11"
         scala:
           - "2.12.12"
-          - "2.13.1"
+          - "2.13.6"
   testWithCoverageReport:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
After #553 this is needed. This fails due to serde compat issues with the new Vector and there's an old PR old #456 that addresses it; @johnynek If there are no objections I'll merge it and also make a new release.