### PR TITLE
Handling serialization of Default Proto instance

### DIFF
--- a/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
+++ b/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
@@ -62,7 +62,7 @@ public class ProtobufSerializer extends Serializer<Message> {
   }
 
   protected Method getParse(Class cls) throws Exception {
-    return getMethodFromCache(cls, methodCache, "parseFrom", new Class[]{byte[].class});
+    return getMethodFromCache(cls, methodCache, "parseFrom", byte[].class);
   }
 
   protected Method getDefaultInstance(Class cls) throws Exception {

--- a/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
+++ b/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
@@ -43,24 +43,26 @@ public class ProtobufSerializer extends Serializer<Message> {
    * classes in play, which should not be very large.
    * We can replace with a LRU if we start to see any issues.
    */
-  final protected HashMap<Class, Method> parseMethodCache = new HashMap<Class, Method>();
+  // Cache for the `parseFrom(byte[] bytes)` method
+  final protected HashMap<Class, Method> methodCache = new HashMap<Class, Method>();
+  // Cache for the `getDefaultInstance()` method
   final protected HashMap<Class, Method> defaultInstanceMethodCache = new HashMap<Class, Method>();
 
   /**
    * This is slow, so we should cache to avoid killing perf:
    * See: http://www.jguru.com/faq/view.jsp?EID=246569
    */
-  private Method getMethodFromCache(Class cls, HashMap<Class, Method> methodCache, String methodName, Class... parameterTypes) throws Exception {
-    Method meth = methodCache.get(cls);
+  private Method getMethodFromCache(Class cls, HashMap<Class, Method> cache, String methodName, Class... parameterTypes) throws Exception {
+    Method meth = cache.get(cls);
     if (null == meth) {
       meth = cls.getMethod(methodName, parameterTypes);
-      methodCache.put(cls, meth);
+      cache.put(cls, meth);
     }
     return meth;
   }
 
   protected Method getParse(Class cls) throws Exception {
-    return getMethodFromCache(cls, parseMethodCache, "parseFrom", new Class[]{byte[].class});
+    return getMethodFromCache(cls, methodCache, "parseFrom", new Class[]{byte[].class});
   }
 
   protected Method getDefaultInstance(Class cls) throws Exception {

--- a/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
+++ b/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
@@ -69,6 +69,9 @@ public class ProtobufSerializer extends Serializer<Message> {
   public Message read(Kryo kryo, Input input, Class<Message> pbClass) {
     try {
       int size = input.readInt(true);
+      if (size == 0) {
+        return (Message) pbClass.getMethod("getDefaultInstance").invoke(null);
+      }
       byte[] barr = new byte[size];
       input.readBytes(barr);
       return (Message)getParse(pbClass).invoke(null, barr);

--- a/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
+++ b/chill-protobuf/src/main/java/com/twitter/chill/protobuf/ProtobufSerializer.java
@@ -50,21 +50,21 @@ public class ProtobufSerializer extends Serializer<Message> {
    * This is slow, so we should cache to avoid killing perf:
    * See: http://www.jguru.com/faq/view.jsp?EID=246569
    */
-  private Method getMethodFromCache(Class cls, String methodName, HashMap<Class, Method> methodCache) throws Exception {
+  private Method getMethodFromCache(Class cls, HashMap<Class, Method> methodCache, String methodName, Class... parameterTypes) throws Exception {
     Method meth = methodCache.get(cls);
     if (null == meth) {
-      meth = cls.getMethod(methodName, new Class[]{ byte[].class });
+      meth = cls.getMethod(methodName, parameterTypes);
       methodCache.put(cls, meth);
     }
     return meth;
   }
 
   protected Method getParse(Class cls) throws Exception {
-    return getMethodFromCache(cls,"parseFrom", parseMethodCache);
+    return getMethodFromCache(cls, parseMethodCache, "parseFrom", new Class[]{byte[].class});
   }
 
   protected Method getDefaultInstance(Class cls) throws Exception {
-    return getMethodFromCache(cls,"getDefaultInstance", defaultInstanceMethodCache);
+    return getMethodFromCache(cls, defaultInstanceMethodCache, "getDefaultInstance");
   }
 
   @Override

--- a/chill-protobuf/src/test/scala/com/twitter/chill/protobuf/ProtobufTest.scala
+++ b/chill-protobuf/src/test/scala/com/twitter/chill/protobuf/ProtobufTest.scala
@@ -27,7 +27,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class ProtobufTest extends AnyWordSpec with Matchers {
-  def buildKyroPoolWithProtoSer(): KryoPool = {
+  def buildKyroPoolWithProtoSer(): KryoPool =
     KryoPool.withByteArrayOutputStream(
       1,
       new KryoInstantiator {
@@ -38,7 +38,6 @@ class ProtobufTest extends AnyWordSpec with Matchers {
         }
       }
     )
-  }
 
   def buildFatigueCount(target: Long, id: Long, count: Int, recentClicks: List[Long]): FatigueCount = {
     val bldr = FatigueCount

--- a/chill-protobuf/src/test/scala/com/twitter/chill/protobuf/ProtobufTest.scala
+++ b/chill-protobuf/src/test/scala/com/twitter/chill/protobuf/ProtobufTest.scala
@@ -27,6 +27,19 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class ProtobufTest extends AnyWordSpec with Matchers {
+  def buildKyroPoolWithProtoSer(): KryoPool = {
+    KryoPool.withByteArrayOutputStream(
+      1,
+      new KryoInstantiator {
+        override def newKryo(): Kryo = {
+          val k = new Kryo
+          k.addDefaultSerializer(classOf[Message], classOf[ProtobufSerializer])
+          k
+        }
+      }
+    )
+  }
+
   def buildFatigueCount(target: Long, id: Long, count: Int, recentClicks: List[Long]): FatigueCount = {
     val bldr = FatigueCount
       .newBuilder()
@@ -39,16 +52,7 @@ class ProtobufTest extends AnyWordSpec with Matchers {
   }
 
   "Protobuf round-trips" in {
-    val kpool = KryoPool.withByteArrayOutputStream(
-      1,
-      new KryoInstantiator {
-        override def newKryo(): Kryo = {
-          val k = new Kryo
-          k.addDefaultSerializer(classOf[Message], classOf[ProtobufSerializer])
-          k
-        }
-      }
-    )
+    val kpool = buildKyroPoolWithProtoSer()
 
     kpool.deepCopy(buildFatigueCount(12L, -1L, 42, List(1L, 2L))) should equal(
       buildFatigueCount(12L, -1L, 42, List(1L, 2L))
@@ -57,5 +61,11 @@ class ProtobufTest extends AnyWordSpec with Matchers {
     // Without the protobuf serializer, this fails:
     val kpoolBusted = KryoPool.withByteArrayOutputStream(1, new KryoInstantiator)
     an[Exception] should be thrownBy kpoolBusted.deepCopy(buildFatigueCount(12L, -1L, 42, List(1L, 2L)))
+  }
+
+  "Default Instance of Should be Ser-DeSer correctly" in {
+    val kpool = buildKyroPoolWithProtoSer()
+
+    kpool.deepCopy(FatigueCount.getDefaultInstance) should equal(FatigueCount.getDefaultInstance)
   }
 }


### PR DESCRIPTION
A Default instance of a Protobuf class serializes to an empty byte array. Hence, an exception is raised when trying to read from a stream with length = 0. Example stacktrace(from **Red**-Green TDD):
```console
Could not create class com.twitter.chill.protobuf.TestMessages$FatigueCount
java.lang.RuntimeException: Could not create class com.twitter.chill.protobuf.TestMessages$FatigueCount
	at com.twitter.chill.protobuf.ProtobufSerializer.read(ProtobufSerializer.java:76)
	at com.twitter.chill.protobuf.ProtobufSerializer.read(ProtobufSerializer.java:40)
	at com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:709)
	at com.twitter.chill.SerDeState.readObject(SerDeState.java:58)
	at com.twitter.chill.KryoPool.fromBytes(KryoPool.java:105)
	at com.twitter.chill.KryoPool.deepCopy(KryoPool.java:87)
	at com.twitter.chill.protobuf.ProtobufTest$$anonfun$2.apply(ProtobufTest.scala:69)
	at com.twitter.chill.protobuf.ProtobufTest$$anonfun$2.apply(ProtobufTest.scala:66)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.wordspec.AnyWordSpecLike$$anon$1.apply(AnyWordSpecLike.scala:1227)
	at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
	at org.scalatest.wordspec.AnyWordSpec.withFixture(AnyWordSpec.scala:1879)
	at org.scalatest.wordspec.AnyWordSpecLike$class.invokeWithFixture$1(AnyWordSpecLike.scala:1224)
	at org.scalatest.wordspec.AnyWordSpecLike$$anonfun$runTest$1.apply(AnyWordSpecLike.scala:1237)
	at org.scalatest.wordspec.AnyWordSpecLike$$anonfun$runTest$1.apply(AnyWordSpecLike.scala:1237)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
	at org.scalatest.wordspec.AnyWordSpecLike$class.runTest(AnyWordSpecLike.scala:1237)
	at org.scalatest.wordspec.AnyWordSpec.runTest(AnyWordSpec.scala:1879)
	at org.scalatest.wordspec.AnyWordSpecLike$$anonfun$runTests$1.apply(AnyWordSpecLike.scala:1296)
	at org.scalatest.wordspec.AnyWordSpecLike$$anonfun$runTests$1.apply(AnyWordSpecLike.scala:1296)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:413)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:401)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:396)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
	at org.scalatest.wordspec.AnyWordSpecLike$class.runTests(AnyWordSpecLike.scala:1296)
	at org.scalatest.wordspec.AnyWordSpec.runTests(AnyWordSpec.scala:1879)
	at org.scalatest.Suite$class.run(Suite.scala:1112)
	at org.scalatest.wordspec.AnyWordSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run(AnyWordSpec.scala:1879)
	at org.scalatest.wordspec.AnyWordSpecLike$$anonfun$run$1.apply(AnyWordSpecLike.scala:1341)
	at org.scalatest.wordspec.AnyWordSpecLike$$anonfun$run$1.apply(AnyWordSpecLike.scala:1341)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
	at org.scalatest.wordspec.AnyWordSpecLike$class.run(AnyWordSpecLike.scala:1341)
	at org.scalatest.wordspec.AnyWordSpec.run(AnyWordSpec.scala:1879)
	at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:45)
	at org.scalatest.tools.Runner$$anonfun$doRunRunRunDaDoRunRun$1.apply(Runner.scala:1322)
	at org.scalatest.tools.Runner$$anonfun$doRunRunRunDaDoRunRun$1.apply(Runner.scala:1316)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1316)
	at org.scalatest.tools.Runner$$anonfun$runOptionallyWithPassFailReporter$2.apply(Runner.scala:972)
	at org.scalatest.tools.Runner$$anonfun$runOptionallyWithPassFailReporter$2.apply(Runner.scala:971)
	at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1482)
	at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:971)
	at org.scalatest.tools.Runner$.run(Runner.scala:798)
	at org.scalatest.tools.Runner.run(Runner.scala)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.runScalaTest2or3(ScalaTestRunner.java:41)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.main(ScalaTestRunner.java:28)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.twitter.chill.protobuf.ProtobufSerializer.read(ProtobufSerializer.java:74)
	... 50 more
Caused by: com.google.protobuf.InvalidProtocolBufferException: Message missing required fields: target_id, suggested_id, serve_count
	at com.google.protobuf.UninitializedMessageException.asInvalidProtocolBufferException(UninitializedMessageException.java:81)
	at com.twitter.chill.protobuf.TestMessages$FatigueCount$Builder.buildParsed(TestMessages.java:324)
	at com.twitter.chill.protobuf.TestMessages$FatigueCount$Builder.access$200(TestMessages.java:271)
	at com.twitter.chill.protobuf.TestMessages$FatigueCount.parseFrom(TestMessages.java:211)
	... 55 more
```
