### PR TITLE
Support all specialized instances of Vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Serialization compatibility is **NOT** guaranteed between releases, and for this
 ### Building Chill
 
 ```bash
-./sbt
-> compile # to build chill
-> publishM2 # to publish chill to your local .m2 repo
-> publish-local # publish to local ivy repo.
+> sbt
+sbt:chill-all>  compile # to build chill
+sbt:chill-all>  publishM2 # to publish chill to your local .m2 repo
+sbt:chill-all>  publishLocal # publish to local ivy repo.
 ```
 
 Chill has a set of subprojects: chill-java, chill-hadoop, chill-storm and chill-scala.  Other than

--- a/chill-scala/src/main/scala-2.13+/com/twitter/chill/AllScalaRegistrarCompat.scala
+++ b/chill-scala/src/main/scala-2.13+/com/twitter/chill/AllScalaRegistrarCompat.scala
@@ -32,8 +32,15 @@ private[chill] class AllScalaRegistrarCompat_0_9_5 extends IKryoRegistrar {
 }
 
 private[chill] class AllScalaRegistrarCompat extends IKryoRegistrar {
-  override def apply(newK: Kryo): Unit =
-    newK
-      .forConcreteTraversableClass(Vector[Any]())
-      .forConcreteTraversableClass(Vector('a))
+  override def apply(newK: Kryo): Unit = {
+    // creating actual BigVector is too heavy, just register the class by name
+    val t: TraversableSerializer[Any, Vector[_]] = new TraversableSerializer(true)
+    newK.forConcreteTraversableClass(Vector[Any]())
+    newK.forConcreteTraversableClass(Vector('a)) // Vector1
+    newK.register(Class.forName("scala.collection.immutable.Vector2"), t)
+    newK.register(Class.forName("scala.collection.immutable.Vector3"), t)
+    newK.register(Class.forName("scala.collection.immutable.Vector4"), t)
+    newK.register(Class.forName("scala.collection.immutable.Vector5"), t)
+    newK.register(Class.forName("scala.collection.immutable.Vector6"), t)
+  }
 }

--- a/chill-scala/src/main/scala-2.13+/com/twitter/chill/AllScalaRegistrarCompat.scala
+++ b/chill-scala/src/main/scala-2.13+/com/twitter/chill/AllScalaRegistrarCompat.scala
@@ -35,8 +35,8 @@ private[chill] class AllScalaRegistrarCompat extends IKryoRegistrar {
   override def apply(newK: Kryo): Unit = {
     // creating actual BigVector is too heavy, just register the class by name
     val t: TraversableSerializer[Any, Vector[_]] = new TraversableSerializer(true)
-    newK.forConcreteTraversableClass(Vector[Any]())
-    newK.forConcreteTraversableClass(Vector('a)) // Vector1
+    newK.register(Class.forName("scala.collection.immutable.Vector0$"), t)
+    newK.register(Class.forName("scala.collection.immutable.Vector1"), t)
     newK.register(Class.forName("scala.collection.immutable.Vector2"), t)
     newK.register(Class.forName("scala.collection.immutable.Vector3"), t)
     newK.register(Class.forName("scala.collection.immutable.Vector4"), t)

--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -140,7 +140,7 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forTraversableSubclass(ListBuffer.empty[Any], isImmutable = false)
       // add mutable Buffer before Vector, otherwise Vector is used
       .forTraversableSubclass(Buffer.empty[Any], isImmutable = false)
-      // Vector is a final class
+      // Vector is a final class / Vector0
       .forTraversableClass(Vector.empty[Any])
       .forTraversableSubclass(ListSet.empty[Any])
       // specifically register small sets since Scala represents them differently

--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -140,7 +140,9 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forTraversableSubclass(ListBuffer.empty[Any], isImmutable = false)
       // add mutable Buffer before Vector, otherwise Vector is used
       .forTraversableSubclass(Buffer.empty[Any], isImmutable = false)
-      // Vector is a final class / Vector0
+      // Vector is a final class in 2.11 / 2.12
+      // for 2.13 we have specific implementations
+      // we should not match subclasses as if conflicts with wrappers
       .forTraversableClass(Vector.empty[Any])
       .forTraversableSubclass(ListSet.empty[Any])
       // specifically register small sets since Scala represents them differently

--- a/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
+++ b/chill-scala/src/main/scala/com/twitter/chill/ScalaKryoInstantiator.scala
@@ -142,7 +142,7 @@ class ScalaCollectionsRegistrar extends IKryoRegistrar {
       .forTraversableSubclass(Buffer.empty[Any], isImmutable = false)
       // Vector is a final class in 2.11 / 2.12
       // for 2.13 we have specific implementations
-      // we should not match subclasses as if conflicts with wrappers
+      // we should not match subclasses as it conflicts with wrappers
       .forTraversableClass(Vector.empty[Any])
       .forTraversableSubclass(ListSet.empty[Any])
       // specifically register small sets since Scala represents them differently

--- a/chill-scala/src/test/scala-2.12-/com/twitter/chill/RegistrationIdsSpecData.scala
+++ b/chill-scala/src/test/scala-2.12-/com/twitter/chill/RegistrationIdsSpecData.scala
@@ -166,11 +166,9 @@ object RegistrationIdsSpecData {
       |145 -> class scala.collection.immutable.Queue$EmptyQueue$
       |146 -> class scala.collection.immutable.MapLike$$anon$1
       |147 -> class scala.collection.immutable.MapLike$$anon$2
-      |148 -> class scala.collection.immutable.MapLike$ImmutableDefaultKeySet""".stripMargin.linesIterator
-      .mkString("\n")
+      |148 -> class scala.collection.immutable.MapLike$ImmutableDefaultKeySet""".stripMargin.linesIterator.toStream
 
-  val RecentEntries = ""
+  val RecentEntries = Stream.empty
 
-  val CurrentEntries =
-    (Entries_0_9_5.linesIterator ++ RecentEntries.linesIterator).mkString("\n")
+  val CurrentEntries = Entries_0_9_5 #::: RecentEntries
 }

--- a/chill-scala/src/test/scala-2.13+/com/twitter/chill/RegistrationIdsSpecData.scala
+++ b/chill-scala/src/test/scala-2.13+/com/twitter/chill/RegistrationIdsSpecData.scala
@@ -167,7 +167,13 @@ object RegistrationIdsSpecData {
 
   val RecentEntries =
     """144 -> class scala.collection.immutable.Vector0$
-      |145 -> class scala.collection.immutable.Vector1""".stripMargin.linesIterator
+      |145 -> class scala.collection.immutable.Vector1
+      |146 -> class scala.collection.immutable.Vector2
+      |147 -> class scala.collection.immutable.Vector3
+      |148 -> class scala.collection.immutable.Vector4
+      |149 -> class scala.collection.immutable.Vector5
+      |150 -> class scala.collection.immutable.Vector6
+      |""".stripMargin.linesIterator
       .mkString("\n")
 
   val CurrentEntries =

--- a/chill-scala/src/test/scala-2.13+/com/twitter/chill/RegistrationIdsSpecData.scala
+++ b/chill-scala/src/test/scala-2.13+/com/twitter/chill/RegistrationIdsSpecData.scala
@@ -164,7 +164,6 @@ object RegistrationIdsSpecData {
       |142 -> class scala.collection.immutable.Queue$EmptyQueue$
       |143 -> class scala.collection.immutable.MapOps$ImmutableKeySet""".stripMargin.linesIterator.toStream
 
-
   val RecentEntries =
     """144 -> class scala.collection.immutable.Vector0$
       |145 -> class scala.collection.immutable.Vector1

--- a/chill-scala/src/test/scala-2.13+/com/twitter/chill/RegistrationIdsSpecData.scala
+++ b/chill-scala/src/test/scala-2.13+/com/twitter/chill/RegistrationIdsSpecData.scala
@@ -162,8 +162,8 @@ object RegistrationIdsSpecData {
       |140 -> class scala.runtime.VolatileByteRef
       |141 -> class scala.math.BigDecimal
       |142 -> class scala.collection.immutable.Queue$EmptyQueue$
-      |143 -> class scala.collection.immutable.MapOps$ImmutableKeySet""".stripMargin.linesIterator
-      .mkString("\n")
+      |143 -> class scala.collection.immutable.MapOps$ImmutableKeySet""".stripMargin.linesIterator.toStream
+
 
   val RecentEntries =
     """144 -> class scala.collection.immutable.Vector0$
@@ -172,10 +172,7 @@ object RegistrationIdsSpecData {
       |147 -> class scala.collection.immutable.Vector3
       |148 -> class scala.collection.immutable.Vector4
       |149 -> class scala.collection.immutable.Vector5
-      |150 -> class scala.collection.immutable.Vector6
-      |""".stripMargin.linesIterator
-      .mkString("\n")
+      |150 -> class scala.collection.immutable.Vector6""".stripMargin.linesIterator.toStream
 
-  val CurrentEntries =
-    (Entries_0_9_5.linesIterator ++ RecentEntries.linesIterator).mkString("\n")
+  val CurrentEntries = Entries_0_9_5 #::: RecentEntries
 }

--- a/chill-scala/src/test/scala-2.13+/com/twitter/chill/SerializedExamplesData.scala
+++ b/chill-scala/src/test/scala-2.13+/com/twitter/chill/SerializedExamplesData.scala
@@ -200,10 +200,16 @@ object SerializedExamplesData {
     142 -> ("kAEBAA==" -> (Queue.empty[Any], true)),
     143 -> ("kQEBAQIC" -> (Map(1 -> 2).keySet, true)),
     144 -> ("kgEBAA==" -> Vector.empty[Int]),
-    145 -> ("kwEBAQIC" -> Vector(1))
+    145 -> ("kwEBAQIC" -> Vector(1)),
+    146 -> ("lAEBQAIC" + "AgIC" * 42 -> Vector.fill(1 << 5 + 1)(1))
+    // Skip BigVectors. too slow
+    // 147 -> ("" -> Vector.fill(1 << 10 + 1)(1)),
+    // 148 -> ("" -> Vector.fill(1 << 15 + 1)(1)),
+    // 149 -> ("" -> Vector.fill(1 << 20 + 1)(1)),
+    // 150 -> ("" -> Vector.fill(1 << 25 + 1)(1)),
   )
 
-  val SpecialCasesNotInExamplesMap: Seq[Int] = Seq(9, 18, 71, 84, 91, 92, 119)
+  val SpecialCasesNotInExamplesMap: Seq[Int] = Seq(9, 18, 71, 84, 91, 92, 119, 147, 148, 149, 150)
 
   val OmitExamplesInScalaVersion: Map[String, Seq[Int]] = Map.empty
 }


### PR DESCRIPTION
When trying to serialize big scala `Vector`, kryo fails with

```
Cause: com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: scala.collection.immutable.Vector3
```

Add support for those types in chill.

Tesing only for `Vector2` as other vectors are too heavy to construct and test