### PR TITLE
Cross-build chill-avro against Scala 2.13 too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           - "11"
         scala:
           - "2.11.12"
-          - "2.12.16"
+          - "2.12.17"
   test:
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +49,7 @@ jobs:
           - "8"
           - "11"
         scala:
-          - "2.12.16"
+          - "2.12.17"
           - "2.13.8"
   testWithCoverageReport:
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ def scalaVersionSpecificFolders(srcBaseDir: java.io.File, scalaVersion: String):
 val sharedSettings = mimaDefaultSettings ++ Seq(
   organization := "com.twitter",
   scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12", "2.12.17", "2.13.9"),
+  crossScalaVersions := Seq("2.11.12", "2.12.17", "2.13.8"),
   scalacOptions ++= Seq("-unchecked", "-deprecation"),
   scalacOptions ++= {
     scalaVersion.value match {

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ def scalaVersionSpecificFolders(srcBaseDir: java.io.File, scalaVersion: String):
 val sharedSettings = mimaDefaultSettings ++ Seq(
   organization := "com.twitter",
   scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12", "2.12.16"),
+  crossScalaVersions := Seq("2.11.12", "2.12.17", "2.13.9"),
   scalacOptions ++= Seq("-unchecked", "-deprecation"),
   scalacOptions ++= {
     scalaVersion.value match {
@@ -167,7 +167,6 @@ lazy val chill = Project(
 ).settings(sharedSettings)
   .settings(
     name := "chill",
-    crossScalaVersions += "2.13.8",
     mimaPreviousArtifacts := Set("com.twitter" %% "chill" % binaryCompatVersion),
     mimaBinaryIssueFilters ++= ignoredABIProblems,
     libraryDependencies += "org.apache.xbean" % "xbean-asm7-shaded" % asmVersion
@@ -182,7 +181,6 @@ def akka(scalaVersion: String) =
 
 lazy val chillAkka = module("akka")
   .settings(
-    crossScalaVersions += "2.13.8",
     resolvers += Resolver.typesafeRepo("releases"),
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.4.2",
@@ -193,7 +191,6 @@ lazy val chillAkka = module("akka")
 
 lazy val chillBijection = module("bijection")
   .settings(
-    crossScalaVersions += "2.13.8",
     libraryDependencies ++= Seq(
       "com.twitter" %% "bijection-core" % bijectionVersion
     )
@@ -239,7 +236,6 @@ lazy val chillThrift = module("thrift").settings(
 
 lazy val chillScrooge = module("scrooge")
   .settings(
-    crossScalaVersions += "2.13.8",
     libraryDependencies ++= Seq(
       ("org.apache.thrift" % "libthrift" % "0.16.0").exclude("junit", "junit"),
       "com.twitter" %% "scrooge-serializer" % scroogeVersion
@@ -270,7 +266,6 @@ lazy val chillAvro = module("avro")
 
 lazy val chillAlgebird = module("algebird")
   .settings(
-    crossScalaVersions += "2.13.8",
     libraryDependencies ++= Seq(
       "com.twitter" %% "algebird-core" % algebirdVersion
     )


### PR DESCRIPTION
Hello, currently Scala 2.13 isn't part of the cross Scala versions for the chill-avro module, is there a reason for that?